### PR TITLE
Updated HScript Handler & few others

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -32,7 +32,7 @@
 	<define name="PSYCH_WATERMARKS"/> <!-- DELETE THIS TO REMOVE WATERMARKS/DEV NAMES ON TITLE SCREEN -->
 	
 	<define name="PRETTY_TRACE" />
-	<define name="CUSTOM_CLASSES" /> <!-- Allows for custom classes using HScript. Increases loading times though-->
+	<define name="CUSTOM_CLASSES" /> <!-- Allows for custom classes using HScript. Increases loading times-->
 
 	<section if="officialBuild">
 		<define name="TITLE_SCREEN_EASTER_EGG"/>
@@ -95,6 +95,7 @@
 	<assets path='art/readme.txt' rename='do NOT readme.txt' />
 
 	<!-- _______________________________ Libraries ______________________________ -->
+	
 	<haxelib name="flixel" version="5.6.2"/>
 	<haxelib name="flixel-ui" version="2.5.0"/>
 	<haxelib name="flixel-addons" version="3.2.2"/>
@@ -107,7 +108,7 @@
 	<haxelib name="hxdiscord_rpc" if="DISCORD_ALLOWED"/>
 	<haxelib name="flxanimate"/>
 	
-	<haxelib name="hscript-improved" if="HSCRIPT_ALLOWED"/>
+	<haxelib name="hscript-improved-dev" if="HSCRIPT_ALLOWED"/>
 	<define name="hscriptPos" />
 
 	<!-- Disable Discord IO Thread -->

--- a/setup/setup-windows.bat
+++ b/setup/setup-windows.bat
@@ -3,15 +3,17 @@ color 0a
 cd ..
 @echo on
 echo Installing dependencies.
-haxelib install lime
-haxelib install openfl
-haxelib install flixel
-haxelib install flixel-addons
-haxelib install flixel-ui
-haxelib install flixel-tools
-haxelib install SScript
+haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
+haxelib set lime 8.0.2
+haxelib set openfl 9.2.2
+haxelib set flixel 5.6.2
+haxelib set flixel-addons 3.2.2
+haxelib set flixel-ui 2.5.0
+haxelib install flixel-tools 
+haxelib install hxWindowColorMode 
 haxelib install hxCodec
 haxelib install tjson
+haxelib git hscript-improved-dev https://github.com/CodenameCrew/hscript-improved.git codename-dev
 haxelib git flxanimate https://github.com/ShadowMario/flxanimate dev
 haxelib git linc_luajit https://github.com/superpowers04/linc_luajit
 haxelib git hxdiscord_rpc https://github.com/MAJigsaw77/hxdiscord_rpc

--- a/source/backend/Log.hx
+++ b/source/backend/Log.hx
@@ -30,7 +30,7 @@ class Log
 		format = '[TIME | FILE] LEVEL MSG';
 	}
 
-	@:keep public static inline function ansi(color:Int):String
+	@:keep public static function ansi(color:Int):String
 		return '\033[30;${color}m';
 
 	static function hxTrace(value:Dynamic, ?pos:PosInfos):Void
@@ -45,7 +45,7 @@ class Log
 	public static function info(value:Dynamic, ?pos:PosInfos):Void
 		print(value, 'INFO', 106, pos);
 
-	static inline function print(value:Dynamic, ?level:String = 'TRACE', ?color:Int = 201, ?pos:PosInfos):Void
+	static public function print(value:Dynamic, ?level:String = 'TRACE', ?color:Int = 201, ?pos:PosInfos):Void
 	{
 		var msg = preformatted.replace('TIME', DateTools.format(Date.now(), '%H:%M:%S')).replace('FILE', '${pos.fileName}:${pos.lineNumber}');
 		msg = msg.replace('LEVEL', '\033[90;48;5;${color}m $level \033[0;0m')
@@ -55,7 +55,7 @@ class Log
 		log.push('${format.replace('TIME', DateTools.format(Date.now(), '%H:%M:%S')).replace('FILE', '${pos.fileName}:${pos.lineNumber}').replace('LEVEL', level).replace('MSG', value)}');
 	}
 
-	@:keep static inline function set_format(val:String):String
+	@:keep static public function set_format(val:String):String
 	{
 		preformatted = val.replace('[', '${ansi(90)}[')
 			.replace(']', '${ansi(90)}]')
@@ -65,5 +65,48 @@ class Log
 			.replace('MSG', '\033[0;0mMSG');
 		return format = val;
 	}
+
+	static public function consoleColorToInt(color:LogColor, isBackground:Bool = false):Int {
+		return switch(color) {
+			case BLACK:
+				(isBackground ? 40 : 30);
+			case RED:
+				(isBackground ? 41 : 31);
+			case GREEN:
+				(isBackground ? 42 : 32);
+			case YELLOW:
+				(isBackground ? 43 : 33);
+			case BLUE:
+				(isBackground ? 44 : 34);
+			case MAGENTA:
+				(isBackground ? 45 : 35);
+			case CYAN:
+				(isBackground ? 46 : 36);
+			case WHITE:
+				(isBackground ? 47 : 37);
+			case DEFAULT:
+				(isBackground ? 49 : 39);
+			case CUSTOM(color):
+				color;
+			default: //also accounts for RESET
+				0;
+		}
+	}
 }
+
+enum LogColor {
+	BLACK;
+	RED;
+	GREEN;
+	YELLOW;
+	BLUE;
+	MAGENTA;
+	CYAN;
+	WHITE;
+	DEFAULT;
+	RESET;
+	CUSTOM(color:Int);
+}
+#else
+typedef Log = haxe.Log; //TODO: Add support for no Pretty Traces
 #end

--- a/source/backend/Macro.hx
+++ b/source/backend/Macro.hx
@@ -20,7 +20,15 @@ class Macro {
 	
 	//Adds any extra classes into the executable, no dce
 	public static final addonClasses:Array<String> = [
-		
+		//"backend" //Log.hx has no field "info"
+
+		//Lime library
+		"lime.app", "lime.graphics",
+		"lime.math", "lime.media", "lime.net",
+		"lime.system", "lime.text", "lime.ui", "lime.util",
+
+		//Openfl library
+		"openfl"
 	];
 
 	@:unreflective public static function compileMacros() {
@@ -28,6 +36,9 @@ class Macro {
 		//doing this since using `#if 32bits` throws an error
 		if(Context.defined("32bits"))
 			Compiler.define("x86_BUILD", "1");
+
+		if(Context.defined("hscript_improved_dev"))
+			Compiler.define("hscript-improved", "1");
 
 		for(classPackage in addonClasses) Compiler.include(classPackage);
 		#end

--- a/source/backend/Mods.hx
+++ b/source/backend/Mods.hx
@@ -25,6 +25,7 @@ class Mods
 		'stages',
 		'weeks',
 		'fonts',
+		#if HSCRIPT_ALLOWED 'libraries', #end
 		'scripts',
 		'achievements'
 	];

--- a/source/backend/Paths.hx
+++ b/source/backend/Paths.hx
@@ -466,6 +466,22 @@ class Paths
 		localTrackedAssets.push(gottenPath);
 		return currentTrackedSounds.get(gottenPath);
 	}
+	
+	#if HSCRIPT_ALLOWED
+	static public function getScriptPath(scriptName:String, ?modFolder:Null<String> = null):String {
+		#if MODS_ALLOWED
+		//If the mod folder is null, then it just uses the current mod directory.
+		if((modFolder == null || modFolder.length == 0) && (Mods.currentModDirectory != null && Mods.currentModDirectory.length > 0))
+			modFolder = Mods.currentModDirectory;
+
+		var scriptPath = Paths.mods(((modFolder != null && modFolder.length > 0) ? modFolder + "/" : "") + scriptName);
+		#else
+		var scriptPath = "assets/" + scriptName;
+		#end
+
+		return scriptPath;
+	}
+	#end
 
 	#if MODS_ALLOWED
 	inline static public function mods(key:String = '') {

--- a/source/hscript/Config.hx
+++ b/source/hscript/Config.hx
@@ -1,13 +1,31 @@
 package hscript;
 
 class Config {
-	public static final ALLOWED_CUSTOM_CLASSES = ["flixel", "backend", "states", "substates", "shaders", "psychlua", "options", "objects", "cutscenes"];
+	public static final ALLOWED_CUSTOM_CLASSES = [
+		"flixel",
+		"backend",
+		"shaders",
+		"psychlua",
+		"options",
+		"objects",
+		"cutscenes"
+	];
 	public static final ALLOWED_ABSTRACT_AND_ENUM = [
+		"backend",
 		"flixel",
 		"openfl",
 		"haxe.xml",
 		"haxe.CallStack"
 	];
-	public static final DISALLOW_CUSTOM_CLASSES = [];
+	public static final DISALLOW_CUSTOM_CLASSES = [
+		"flixel.FlxGame",
+		"flixel.addons.ui.FlxUI9SliceSprite",
+		"flixel.addons.ui.FlxUIList",
+		"flixel.addons.ui.FlxUICursor",
+		"flixel.addons.ui.FlxUINumericStepper",
+		
+		//Lime
+		"hxp.Path"
+	];
 	public static final DISALLOW_ABSTRACT_AND_ENUM = [];
 }

--- a/source/hscript/CustomClass.hx
+++ b/source/hscript/CustomClass.hx
@@ -1,0 +1,355 @@
+package hscript;
+
+import hscript.utils.UnsafeReflect;
+import haxe.Constraints.Function;
+
+using Lambda;
+
+/**
+ * The Custom Class core.
+ * 
+ * Provides handlers for custom classes.
+ * 
+ * @author Jamextreme140
+ */
+@:access(hscript.CustomClassHandler)
+@:access(hscript.Property)
+class CustomClass implements IHScriptCustomClassBehaviour {
+	public var className(get, never):String;
+
+	private function get_className():String
+		return __class.name;
+
+	public var __interp:Interp;
+	public var __real_fields:Array<String> = []; // UNUSED
+	public var __class__fields:Array<String> = []; // Declared fields
+
+	public var __allowSetGet:Bool = true;
+
+	var __class:CustomClassHandler;
+	var __superClass:IHScriptCustomClassBehaviour;
+	var __upperClass:IHScriptCustomClassBehaviour;
+	var __constructor:Function;
+
+	var __overrideFields:Array<String> = [];
+	var __cachedFieldSet:Map<String, Dynamic> = null;
+	var initializing:Bool = false;
+
+	public function new(__class:CustomClassHandler, ?args:Array<Dynamic>, ?cachedFieldSet:Map<String, Dynamic>) {
+		this.__class = __class;
+
+		__interp = new Interp();
+		__interp.errorHandler = __class.__interp.errorHandler;
+		__interp.importFailedCallback = __class.__interp.importFailedCallback;
+
+		// __interp.variables = __class.staticInterp.variables;
+		@:privateAccess __interp.usingHandler.usingEntries = __class.ogInterp.usingHandler.usingEntries;
+		__interp.publicVariables = __class.ogInterp.publicVariables;
+		__interp.staticVariables = __class.ogInterp.staticVariables;
+		__interp.customClasses = __class.ogInterp.customClasses;
+
+		for(f => v in __class.__interp.variables) {
+			if(f == 'new') continue;
+			if (!__interp.variables.exists(f))
+				__interp.variables.set(f, v);
+		}
+
+		for (f in __class.fields) {
+			switch (Tools.expr(f)) {
+				case EVar(n): __class__fields.push(n);
+				case EFunction(_, _, n, _, _, _, isOverride): 
+					if(isOverride) __overrideFields.push(n);
+					__class__fields.push(n);
+				default: continue;
+			}
+			@:privateAccess __interp.exprReturn(f);
+		}
+
+		__interp.scriptObject = this;
+
+		initializing = true;
+
+		if(cachedFieldSet != null)
+			for(f => v in cachedFieldSet)
+				this.hset(f, v);
+
+		if (hasField('new')) {
+			buildConstructor();
+			call('new', args);
+
+			if(__cachedFieldSet != null) {
+				__cachedFieldSet.clear();
+				__cachedFieldSet = null;
+			}
+
+			if (this.__superClass == null && __class.extend != null)
+				__interp.error(ECustom("super() not called"));
+		} else if (__class.extend != null) {
+			buildSuperClass(args);
+		}
+
+		initializing = false;
+	}
+
+	function cacheFieldSet(name:String, val:Dynamic) {
+		if(!initializing) return;
+		if(__cachedFieldSet == null) __cachedFieldSet = [];
+		__cachedFieldSet.set(name, val);
+	}
+
+	function buildConstructor() {
+		__constructor = Reflect.makeVarArgs(buildSuperClass);
+	}
+
+	function buildSuperClass(?args:Array<Dynamic>) {
+		if (args == null)
+			args = [];
+
+		if (__class.cl == null) {
+			__interp.error(ECustom('Current class does not have a super'));
+			return;
+		}
+
+		if (__class.cl is CustomClassHandler) {
+			var customClass = new CustomClass(__class.cl, args, __cachedFieldSet);
+			if(__overrideFields.length > 0) {
+				for (field in __overrideFields) {
+					var func = __interp.variables.get(field);
+					customClass.overrideField(field, func);
+				}
+			}
+			customClass.__upperClass = this;
+			__superClass = customClass;
+			@:privateAccess __interp.__instanceFields = __interp.__instanceFields.concat(getSuperFields());
+		} else {
+			if(__cachedFieldSet != null)
+				UnsafeReflect.setField(__class.cl, "__cachedFieldSet", __cachedFieldSet);
+
+			__superClass = Type.createInstance(__class.cl, args);
+			var disallowCopy:Array<String> = {
+				var fieldMap:Map<String, String> = []; // Prevent duplicate values
+				for(f in Reflect.fields(__superClass).concat(Type.getInstanceFields(Type.getClass(__superClass))))
+					fieldMap.set(f, f);
+
+				fieldMap.array();
+			}
+			this.__real_fields = disallowCopy;
+			@:privateAccess __interp.__instanceFields = __interp.__instanceFields.concat(disallowCopy);
+			__superClass.__real_fields = this.__real_fields;
+			__superClass.__class__fields = this.__class__fields;
+			__superClass.__interp = this.__interp;
+		}
+	}
+
+	public function call(name:String, ?args:Array<Dynamic>, ?toSuper:Bool = false):Dynamic {
+		var superFnName:Null<String> = toSuper ? '_HX_SUPER__$name' : null;
+		var fn:Dynamic = {
+			if(toSuper && __interp.variables.exists(superFnName)) {
+				__interp.variables.get(superFnName);
+			}
+			else 
+				__interp.variables.get(name);
+		};
+
+		if (fn != null && Reflect.isFunction(fn))
+			return UnsafeReflect.callMethodUnsafe(null, fn, (args == null) ? [] : args);
+		else
+			__interp.error(ECustom('$name doesn\'t exists or is not a function'));
+		return null;
+	}
+
+	function hasField(name:String) {
+		return __class__fields.contains(name);
+	}
+
+	function hasStaticField(name:String):Bool {
+		return __class.hasField(name);
+	}
+
+	function getField(name:String, allowProperty:Bool = true):Dynamic {
+		var f = __interp.variables.get(name);
+		if (f != null && allowProperty && f is Property) {
+			var prop:Property = cast f;
+			prop.__allowSetGet = this.__allowSetGet;
+			var r = prop.callGetter(name);
+			prop.__allowSetGet = null;
+			return r;
+		}
+		return f;
+	}
+
+	function setField(name:String, val:Dynamic):Dynamic {
+		var f = getField(name, false);
+		if (f != null && f is Property) {
+			var prop:Property = cast f;
+			prop.__allowSetGet = this.__allowSetGet;
+			var r = prop.callSetter(name, val);
+			prop.__allowSetGet = null;
+			return r;
+		}
+		__interp.variables.set(name, val);
+		return val;
+	}
+
+	/**
+	 * Overrides (replaces) the declared function.
+	 * @param name 
+	 * @param func 
+	 */
+	function overrideField(name:String, func:Function) {
+		var f = getField(name, false);
+		if(f != null && Reflect.isFunction(f)) {
+			__interp.variables.set(name, func);
+			__interp.variables.set('_HX_SUPER__$name', f);
+		}
+		else if(__superClass != null && __superClass is CustomClass) {
+			cast(__superClass, CustomClass).overrideField(name, func);
+		}
+	}
+
+	function superHasField(name:String) {
+		if (__superClass == null)
+			return false;
+
+		var realFieldExists = __superClass.__real_fields != null && __superClass.__real_fields.contains(name);
+		var classFieldExists = __superClass.__class__fields != null && __superClass.__class__fields.contains(name);
+
+		if(!realFieldExists && !classFieldExists && __superClass is CustomClass)
+			return cast(__superClass, CustomClass).superHasField(name);
+
+		return realFieldExists || classFieldExists;
+	}
+
+	function getSuperFields():Array<String> {
+		if(__superClass == null) return [];
+
+		var classFields:Map<String, String> = []; // Prevents duplicated values
+		var cls:Null<IHScriptCustomClassBehaviour> = __superClass;
+
+		while (cls != null) {
+			for(fieldSet in [cls.__class__fields, cls.__real_fields])
+				for(f in fieldSet)
+					classFields.set(f, f);
+			var next:IHScriptCustomClassBehaviour = null;
+			if(cls is CustomClass)
+				next = cast(cls, CustomClass).__superClass;
+			if (next == null)
+				break;
+			cls = next;
+		}
+
+		return [for(f in classFields) f];
+	}
+
+	public function hget(name:String):Dynamic {
+		switch (name) {
+			case 'superClass': return __superClass;
+			case 'superConstructor': return __constructor;
+			default:
+				if (hasField(name))
+					return getField(name);
+
+				if (hasStaticField(name)) {
+					__interp.error(ECustom('The field ${name} should be accessed in a static way.'));
+					return null;
+				}
+
+				if (__superClass != null) {
+					if (superHasField(name)) {
+						__superClass.__allowSetGet = this.__allowSetGet;
+						return __superClass.hget(name);
+					}
+				}
+
+				throw "field '"
+					+ name
+					+ "' does not exist in custom class '"
+					+ this.className
+					+ "'"
+					+ (__superClass != null ? "' or super class '" + Type.getClassName(Type.getClass(this.__superClass)) + "'" : "");
+		}
+		return null;
+	}
+
+	public function hset(name:String, val:Dynamic):Dynamic {
+		if (hasField(name)) 
+			return setField(name, val);
+
+		if (hasStaticField(name)) {
+			__interp.error(ECustom('The field ${name} should be accessed in a static way.'));
+			return null;
+		}
+
+		if (__superClass != null) {
+			if (superHasField(name)) {
+				__superClass.__allowSetGet = this.__allowSetGet;
+				return __superClass.hset(name, val);
+			}
+		}
+		else if(__class.extend != null && initializing) {
+			cacheFieldSet(name, val);
+			return val;
+		}
+
+		throw "field '"
+			+ name
+			+ "' does not exist in custom class '"
+			+ this.className
+			+ "'"
+			+ (__superClass != null ? "' or super class '" + Type.getClassName(Type.getClass(this.__superClass)) + "'" : "");
+
+		return null;
+	}
+
+	// UNUSED
+	public function __callGetter(name:String):Dynamic {
+		return null;
+	}
+
+	public function __callSetter(name:String, val:Dynamic):Dynamic {
+		return null;
+	}
+
+	/**
+	 * Returns the real superClass if the Custom Class
+	 * extends another Custom Class, and so on until
+	 * it reaches a real class, otherwise it will
+	 * return the last fetched Custom Class
+	 * @return Null<Dynamic>
+	 */
+	public function getSuperclass():IHScriptCustomClassBehaviour {
+		if(__superClass == null) return null;
+		
+		var cls:Null<IHScriptCustomClassBehaviour> = __superClass;
+
+		// Check if the superClass is another custom class,
+		// so it will find for a real class, otherwise
+		// returns the last super CustomClass parent.
+		while (cls != null && cls is CustomClass) {
+			var next = cast(cls, CustomClass).__superClass;
+			if (next == null)
+				break; // Return the Custom Class itself
+			cls = next;
+		}
+		return cls is CustomClass ? this : cls;
+	}
+
+	// TODO: scripted safe cast for custom classes
+	public function getUpperclass():IHScriptCustomClassBehaviour {
+		if(__upperClass == null) return this;
+
+		var cls:CustomClass = cast __upperClass;
+
+		while (cls != null) {
+			var prev:CustomClass = cast cls.__upperClass;
+			if(prev == null)
+				break;
+			cls = prev;
+		}
+
+		return cls;
+	}
+
+	public function toString():String
+		return className;
+}

--- a/source/hscript/Expr.hx
+++ b/source/hscript/Expr.hx
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package hscript;
+
+typedef Int8 = #if cpp cpp.Int8 #elseif java java.Int8 #elseif cs cs.Int8 #else Int #end;
+typedef Int16 = #if cpp cpp.Int16 #elseif java java.Int16 #elseif cs cs.Int16 #else Int #end;
+typedef Int32 = #if cpp cpp.Int32 #else Int #end;
+typedef Int64 = #if cpp cpp.Int64 #elseif java java.Int64 #elseif cs cs.Int64 #else Int #end;
+
+typedef UInt8 = #if cpp cpp.UInt8 #elseif cs cs.UInt8 #else Int #end;
+typedef UInt16 = #if cpp cpp.UInt16 #elseif cs cs.UInt16 #else Int #end;
+typedef UInt32 = #if cpp cpp.UInt32 #else Int #end;
+typedef UInt64 = #if cpp cpp.UInt64 #else Int #end;
+
+enum Const {
+	CInt( v : Int );
+	CFloat( f : Float );
+	CString( s : String, ?i : Bool );
+}
+
+#if hscriptPos
+@:structInit
+final class Expr {
+	public var e : ExprDef;
+	public var pmin : Int;
+	public var pmax : Int;
+	public var origin : String;
+	public var line : Int;
+}
+enum ExprDef {
+#else
+typedef ExprDef = Expr;
+enum Expr {
+#end
+	EConst( c : Const );
+	EIdent( v : String );
+	EVar( n : String, ?t : CType, ?e : Expr, ?isPublic : Bool, ?isStatic : Bool, ?isPrivate : Bool, ?isFinal : Bool, ?isInline : Bool, ?get : FieldPropertyAccess, ?set : FieldPropertyAccess, ?isVar:Bool );
+	EParent( e : Expr );
+	EBlock( e : Array<Expr> );
+	EField( e : Expr, f : String , ?safe : Bool );
+	EBinop( op : String, e1 : Expr, e2 : Expr );
+	EUnop( op : String, prefix : Bool, e : Expr );
+	ECall( e : Expr, params : Array<Expr> );
+	EIf( cond : Expr, e1 : Expr, ?e2 : Expr );
+	EWhile( cond : Expr, e : Expr );
+	EFor( v : String, it : Expr, e : Expr, ?ithv: String);
+	EBreak;
+	EContinue;
+	EFunction( args : Array<Argument>, e : Expr, ?name : String, ?ret : CType, ?isPublic : Bool, ?isStatic : Bool, ?isOverride : Bool, ?isPrivate : Bool, ?isFinal : Bool, ?isInline : Bool );
+	EReturn( ?e : Expr );
+	EArray( e : Expr, index : Expr );
+	EArrayDecl( e : Array<Expr>, ?wantedType: CType );
+	ENew( cl : String, params : Array<Expr>, ?paramType:Array<CType> );
+	EThrow( e : Expr );
+	ETry( e : Expr, v : String, t : Null<CType>, ecatch : Expr );
+	EObject( fl : Array<ObjectField> );
+	ETernary( cond : Expr, e1 : Expr, e2 : Expr );
+	ESwitch( e : Expr, cases : Array<SwitchCase>, ?defaultExpr : Expr );
+	EDoWhile( cond : Expr, e : Expr);
+	EMeta( name : String, args : Array<Expr>, e : Expr );
+	ECheckType( e : Expr, t : CType );
+
+	EPackage( ?n:String );
+	EImport( c : String, ?asname:String, ?isUsing:Bool );
+	EClass( name:String, fields:Array<Expr>, ?extend:String, interfaces:Array<String>, ?isFinal:Bool, ?isPrivate:Bool );
+	EEnum( en:EnumDecl, ?isAbstract:Bool );
+	ECast(e:Expr, ?t:CType);
+	ERegex(e:String, flags:String);
+}
+
+@:structInit
+final class ObjectField {
+	public var name : String;
+	public var e : Expr;
+}
+
+@:structInit
+final class SwitchCase {
+	public var values : Array<Expr>;
+	public var expr : Expr;
+}
+
+@:structInit
+final class Argument {
+	public var name : String;
+	public var t : CType;
+	public var opt : Bool;
+	public var value : Expr;
+}
+
+@:structInit
+final class MetadataEntry {
+	public var name : String;
+	public var params : Array<Expr>;
+}
+
+typedef Metadata = Array<MetadataEntry>;
+
+@:structInit
+final class EnumDecl {
+	public var name : String;
+	public var fields : Array<EnumField>;
+}
+
+@:structInit
+final class EnumField {
+	public var name : String;
+	public var args : Array<Argument>;
+}
+
+enum CType {
+	CTPath( path : Array<String>, ?params : Array<CType> );
+	CTFun( args : Array<CType>, ret : CType );
+	CTAnon( fields : Array<{ name : String, t : CType, ?meta : Metadata }> );
+	CTParent( t : CType );
+	CTOpt( t : CType );
+	CTNamed( n : String, t : CType );
+	CTExpr( e : Expr ); // for type parameters only
+}
+
+#if hscriptPos
+class Error {
+	public var e : ErrorDef;
+	public var pmin : Int;
+	public var pmax : Int;
+	public var origin : String;
+	public var line : Int;
+	public function new(e, pmin, pmax, origin, line) {
+		this.e = e;
+		this.pmin = pmin;
+		this.pmax = pmax;
+		this.origin = origin;
+		this.line = line;
+	}
+	public function toString(): String {
+		return Printer.errorToString(this);
+	}
+}
+enum ErrorDef {
+#else
+enum Error {
+#end
+	EInvalidChar( c : Int );
+	EUnexpected( s : String );
+	EUnterminatedString;
+	EUnterminatedComment;
+	EInvalidPreprocessor( msg : String );
+	EUnknownVariable( v : String );
+	EInvalidIterator( v : String );
+	EInvalidOp( op : String );
+	EInvalidAccess( f : String );
+	ECustom( msg : String );
+	EInvalidClass( className : String);
+	EAlreadyExistingClass( className : String);
+}
+
+
+enum ModuleDecl {
+	DPackage( path : Array<String> );
+	DImport( path : Array<String>, ?everything : Bool );
+	DClass( c : ClassDecl );
+	DTypedef( c : TypeDecl );
+}
+
+typedef ModuleType = {
+	var name : String;
+	var params : {}; // TODO : not yet parsed
+	var meta : Metadata;
+	var isPrivate : Bool;
+}
+
+typedef ClassDecl = {> ModuleType,
+	var extend : Null<CType>;
+	var implement : Array<CType>;
+	var fields : Array<FieldDecl>;
+	var isExtern : Bool;
+}
+
+typedef TypeDecl = {> ModuleType,
+	var t : CType;
+}
+
+typedef FieldDecl = {
+	var name : String;
+	var meta : Metadata;
+	var kind : FieldKind;
+	var access : Array<FieldAccess>;
+}
+
+enum abstract FieldAccess(UInt8) {
+	var APublic;
+	var APrivate;
+	var AInline;
+	var AOverride;
+	var AStatic;
+	var AMacro;
+}
+
+enum abstract FieldPropertyAccess(UInt8) {
+	var ADefault;
+	var ANull;
+	var AGet;
+	var ASet;
+	var ADynamic;
+	var ANever;
+}
+
+enum FieldKind {
+	KFunction( f : FunctionDecl );
+	KVar( v : VarDecl );
+}
+
+@:structInit
+final class FunctionDecl {
+	public var args : Array<Argument>;
+	public var body : Expr;
+	public var ret : Null<CType>;
+}
+
+typedef VarDecl = {
+	var get : Null<String>;
+	var set : Null<String>;
+	var expr : Null<Expr>;
+	var type : Null<CType>;
+}

--- a/source/hscript/HEnum.hx
+++ b/source/hscript/HEnum.hx
@@ -1,0 +1,79 @@
+package hscript;
+
+import hscript.utils.UnsafeReflect;
+
+// TODO: EnumTools for scripted enums
+/**
+ * Wrapper class for enums, both for real and scripted.
+ */
+@:structInit
+class HEnum implements IHScriptCustomBehaviour {
+	private var enumValues(default, null) = {};
+
+	public function setEnum(name:String, enumValue:Dynamic):Void {
+		UnsafeReflect.setField(enumValues, name, enumValue);
+	}
+
+	public function getEnum(name:String):Null<Dynamic> {
+		if (UnsafeReflect.hasField(enumValues, name))
+			return UnsafeReflect.field(enumValues, name);
+		return null;
+	}
+
+	public function hget(name:String):Dynamic {
+		return getEnum(name);
+	}
+
+	public function hset(name:String, val:Dynamic):Dynamic {
+		return null;
+	}
+}
+
+@:nullSafety
+@:structInit
+class HEnumValue {
+	public var enumName:String;
+	public var fieldName:String;
+	public var index:Int;
+	public var args:Array<Dynamic>;
+
+	public function toString():String {
+		return '$enumName.$fieldName${args.length > 0 ? '(${[for (a in args) a].join(", ")})' : ''}';
+	}
+
+	public inline function getEnumName():String
+		return this.enumName;
+
+	public inline function getConstructorArgs():Array<Dynamic>
+		return this.args;
+
+	public function compare(other:HEnumValue):Bool {
+		if (enumName != other.enumName || fieldName != other.fieldName)
+			return false;
+		if (args.length == 0 && other.args.length == 0)
+			return true;
+		if (args.length == 0 || other.args.length == 0)
+			return false;
+		if (args.length != other.args.length)
+			return false;
+
+		for (i in 0...args.length) // TODO: allow deep comparison, like arrays
+			if (args[i] != other.args[i])
+				return false;
+
+		return true;
+	}
+
+	// functions from base enums
+	public function equals(otherEnum:HEnumValue):Bool
+		return this.compare(otherEnum);
+
+	public function getIndex():Int
+		return this.index;
+
+	public function getName():String
+		return this.fieldName;
+
+	public function getParameters():Array<Dynamic>
+		return this.getConstructorArgs();
+}

--- a/source/hscript/Interp.hx
+++ b/source/hscript/Interp.hx
@@ -28,9 +28,10 @@
  */
 package hscript;
 
-import haxe.iterators.StringKeyValueIteratorUnicode;
-import haxe.EnumTools;
-import haxe.display.Protocol.InitializeResult;
+import hscript.HEnum.HEnumValue;
+import haxe.CallStack;
+import hscript.utils.UsingHandler;
+import hscript.utils.UnsafeReflect;
 import haxe.PosInfos;
 import hscript.Expr;
 import haxe.Constraints.IMap;
@@ -43,78 +44,138 @@ private enum Stop {
 	SReturn;
 }
 
+enum abstract ScriptObjectType(UInt8) {
+	var SClass;
+	var SObject;
+	var SStaticClass;
+	var SCustomClass; // custom classes
+	var SBehaviourClass; // hget and hset
+	var SAccessBehaviourObject; // hget and hset with __allowSetGet
+	var SNull;
+}
+
+@:structInit
+class DeclaredVar {
+	public var r:Dynamic;
+	public var depth:Int;
+}
+
+@:structInit
+class RedeclaredVar {
+	public var n:String;
+	public var old:DeclaredVar;
+	public var depth:Int;
+}
+
+@:access(hscript.CustomClass)
+@:analyzer(optimize, local_dce, fusion, user_var_fusion)
 class Interp {
+	private var hasScriptObject(get, never):Bool;
+	private function get_hasScriptObject():Bool 
+		return scriptObject != null;
+
+	private var _scriptObjectType(default, null):ScriptObjectType = SNull;
+
+	var __instanceFields:Array<String> = [];
+
 	public var scriptObject(default, set):Dynamic;
 	public function set_scriptObject(v:Dynamic) {
-		__instanceFields = (v == null) ? [] : Type.getInstanceFields(Type.getClass(v));
+		switch(Type.typeof(v)) {
+			case TClass(c): // Class Access
+				__instanceFields = Type.getInstanceFields(c);
+				if(v is IHScriptCustomClassBehaviour) {
+					var v:IHScriptCustomClassBehaviour = cast v;
+					var classFields = v.__class__fields;
+					if(classFields != null)
+						__instanceFields = __instanceFields.concat(classFields);
+					_scriptObjectType = SCustomClass;
+				} else if(v is IHScriptCustomAccessBehaviour) {
+					_scriptObjectType = SAccessBehaviourObject;
+				} else if(v is IHScriptCustomBehaviour) {
+					_scriptObjectType = SBehaviourClass;
+				} else {
+					_scriptObjectType = SClass;
+				}
+			case TObject: // Object Access or Static Class Access
+				var cls = Type.getClass(v);
+				switch(Type.typeof(cls)) {
+					case TClass(c): // Static Class Access
+						__instanceFields = Type.getInstanceFields(c);
+						_scriptObjectType = SStaticClass;
+					default: // Object Access
+						__instanceFields = Reflect.fields(v);
+						_scriptObjectType = SObject;
+				}
+			default: // Null or other
+				__instanceFields = [];
+				_scriptObjectType = SNull;
+		}
 		return scriptObject = v;
 	}
+
+	var inCustomClass(get, never):Bool;
+	private function get_inCustomClass():Bool
+		return hasScriptObject && _scriptObjectType == SCustomClass;
+
+	var __customClass(get, never):CustomClass;
+	private function get___customClass():CustomClass
+		return inCustomClass ? cast scriptObject : null;
+
 	public var errorHandler:Error->Void;
-	public var importFailedCallback:Array<String>->Bool;
+	public var warnHandler:Error->Void;
+	public var importFailedCallback:Array<String>->Null<String>->Bool;
 	public var onMetadata:String->Array<Expr>->Expr->Dynamic;
-	#if haxe3
-	public var customClasses:Map<String, Dynamic>;
+
+	public var customClasses:Map<String, CustomClassHandler>;
 	public var variables:Map<String, Dynamic>;
 	public var publicVariables:Map<String, Dynamic>;
 	public var staticVariables:Map<String, Dynamic>;
 
-	public var locals:Map<String, {r:Dynamic, depth:Int}>;
+	// warning can be null
+	public var locals:Map<String, DeclaredVar>;
 	var binops:Map<String, Expr->Expr->Dynamic>;
-	#else
-	public var customClasses:Hash<Dynamic>;
-	public var variables:Hash<Dynamic>;
-	public var publicVariables:Hash<Dynamic>;
-	public var staticVariables:Hash<Dynamic>;
-
-	public var locals:Hash<{r:Dynamic, depth:Int}>;
-	var binops:Hash<Expr->Expr->Dynamic>;
-	#end
 
 	var depth:Int = 0;
 	var inTry:Bool;
-	var declared:Array<{n:String, old:{r:Dynamic, depth:Int}, depth:Int}>;
+	var declared:Array<RedeclaredVar>;
 	var returnValue:Dynamic;
 
 	var isBypassAccessor:Bool = false;
+	var setAlias:Null<String> = null; // Custom Class import alias
+	var beforeAlias:Null<String> = null;
 
 	public var importEnabled:Bool = true;
+	public var allowStaticImports:Bool = true;
 
 	public var allowStaticVariables:Bool = false;
 	public var allowPublicVariables:Bool = false;
 
+	// TODO: move this to an external class
 	public var importBlocklist:Array<String> = [
 		// "flixel.FlxG"
 	];
 
-	var __instanceFields:Array<String> = [];
+	var usingHandler:UsingHandler;
+
 	#if hscriptPos
 	var curExpr:Expr;
 	#end
 
 	public function new() {
-		#if haxe3
 		locals = new Map();
-		#else
-		locals = new Hash();
-		#end
-		declared = new Array();
+		declared = [];
 		resetVariables();
 		initOps();
 	}
 
-	private function resetVariables() {
-		#if haxe3
-		customClasses = new Map<String, Dynamic>();
+	private function resetVariables():Void {
+		customClasses = new Map<String, CustomClassHandler>();
 		variables = new Map<String, Dynamic>();
 		publicVariables = new Map<String, Dynamic>();
 		staticVariables = new Map<String, Dynamic>();
-		#else
-		customClasses = new Hash();
-		variables = new Hash();
-		publicVariables = new Hash();
-		staticVariables = new Hash();
-		#end
 
+		usingHandler = new UsingHandler();
+		
 		variables.set("null", null);
 		variables.set("true", true);
 		variables.set("false", false);
@@ -135,13 +196,9 @@ class Interp {
 		return cast {fileName: "hscript", lineNumber: 0};
 	}
 
-	function initOps() {
+	function initOps():Void {
 		var me = this;
-		#if haxe3
 		binops = new Map();
-		#else
-		binops = new Hash();
-		#end
 		binops.set("+", function(e1, e2) return me.expr(e1) + me.expr(e2));
 		binops.set("-", function(e1, e2) return me.expr(e1) - me.expr(e2));
 		binops.set("*", function(e1, e2) return me.expr(e1) * me.expr(e2));
@@ -167,12 +224,7 @@ class Interp {
 			var expr1:Dynamic = me.expr(e1);
 			return expr1 == null ? me.expr(e2) : expr1;
 		});
-		binops.set("...", function(e1, e2) return new
-			#if (haxe_211 || haxe3)
-			IntIterator
-			#else
-			IntIter
-			#end(me.expr(e1), me.expr(e2)));
+		binops.set("...", function(e1, e2) return new IntIterator(me.expr(e1), me.expr(e2)));
 		assignOp("+=", function(v1:Dynamic, v2:Dynamic) return v1 + v2);
 		assignOp("-=", function(v1:Float, v2:Float) return v1 - v2);
 		assignOp("*=", function(v1:Float, v2:Float) return v1 * v2);
@@ -184,10 +236,10 @@ class Interp {
 		assignOp("<<=", function(v1, v2) return v1 << v2);
 		assignOp(">>=", function(v1, v2) return v1 >> v2);
 		assignOp(">>>=", function(v1, v2) return v1 >>> v2);
-		assignOp("??=", function(v1, v2) return v1 == null ? v2 : v1);
+		assignOp("??" + "=", function(v1, v2) return v1 == null ? v2 : v1);
 	}
 
-	function checkIsType(e1,e2): Bool {
+	function checkIsType(e1:Expr,e2:Expr): Bool {
 		var expr1:Dynamic = expr(e1);
 
 		return switch(Tools.expr(e2))
@@ -198,11 +250,25 @@ class Interp {
 				Std.isOfType(expr1, IMap);
 			default:
 				var expr2:Dynamic = expr(e2);
-				expr2 != null ? Std.isOfType(expr1, expr2) : false;
+				if(expr2 != null) {
+					if(expr1 is CustomClass && expr2 is CustomClassHandler) {
+						var objName = cast(expr1, CustomClass).className;
+						var clsName = cast(expr2, CustomClassHandler).name;
+						objName == clsName;
+					}
+					else 
+						Std.isOfType(expr1, expr2);
+				}
+				else 
+					false;
 		}
 	}
 
-	public function setVar(name:String, v:Dynamic) {
+	public function varExists(name:String):Bool {
+		return allowStaticVariables && staticVariables.exists(name) || allowPublicVariables && publicVariables.exists(name) || variables.exists(name);
+	}
+
+	public function setVar(name:String, v:Dynamic):Void {
 		if (allowStaticVariables && staticVariables.exists(name))
 			staticVariables.set(name, v);
 		else if (allowPublicVariables && publicVariables.exists(name))
@@ -217,27 +283,51 @@ class Interp {
 			case EIdent(id):
 				var l = locals.get(id);
 				if (l == null) {
-					if (!variables.exists(id) && !staticVariables.exists(id) && !publicVariables.exists(id) && scriptObject != null) {
-						if (Type.typeof(scriptObject) == TObject) {
-							Reflect.setField(scriptObject, id, v);
-						} else {
-							if (isBypassAccessor) {
-								if (__instanceFields.contains(id)) {
-									Reflect.setField(scriptObject, id, v);
-									return v;
-								}
+					if (hasScriptObject && !varExists(id)) {
+						var instanceHasField = __instanceFields.contains(id);
+
+						if (_scriptObjectType == SObject && instanceHasField) {
+							UnsafeReflect.setField(scriptObject, id, v);
+							return v;
+						} else if((_scriptObjectType == SCustomClass && instanceHasField) || _scriptObjectType == SAccessBehaviourObject) {
+							var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+							if(isBypassAccessor) {
+								obj.__allowSetGet = false;
+								var res = obj.hset(id, v);
+								obj.__allowSetGet = true;
+								return res;
 							}
-							if (__instanceFields.contains(id)) {
-								Reflect.setProperty(scriptObject, id, v);
-							} else if (__instanceFields.contains('set_$id')) { // setter
-								Reflect.getProperty(scriptObject, 'set_$id')(v);
+							return obj.hset(id, v);
+						}
+						else if (_scriptObjectType == SBehaviourClass) {
+							var obj:IHScriptCustomBehaviour = cast scriptObject;
+							return obj.hset(id, v);
+						}
+
+						if (instanceHasField) {
+							if(isBypassAccessor) {
+								UnsafeReflect.setField(scriptObject, id, v);
+								return v;
 							} else {
-								setVar(id, v);
+								UnsafeReflect.setProperty(scriptObject, id, v);
+								return UnsafeReflect.field(scriptObject, id);
 							}
+						} else if (__instanceFields.contains('set_$id')) { // setter
+							return UnsafeReflect.getProperty(scriptObject, 'set_$id')(v);
+						} else {
+							setVar(id, v);
 						}
 					} else {
+						var obj = resolve(id, false, false);
+						if (obj != null && obj is Property) {
+							var prop:Property = cast obj;
+							return prop.callSetter(id, v);
+						}
 						setVar(id, v);
 					}
+				} else if (l.r is Property) {
+					var prop:Property = cast l.r;
+					return prop.callSetter(id, v);
 				} else {
 					l.r = v;
 					if (l.depth == 0) {
@@ -264,28 +354,72 @@ class Interp {
 		return v;
 	}
 
-	function assignOp(op, fop:Dynamic->Dynamic->Dynamic) {
+	function assignOp(op:String, fop:Dynamic->Dynamic->Dynamic):Void {
 		var me = this;
 		binops.set(op, function(e1, e2) return me.evalAssignOp(op, fop, e1, e2));
 	}
 
-	function evalAssignOp(op, fop, e1, e2):Dynamic {
+	function evalAssignOp(op:String, fop:Dynamic->Dynamic->Dynamic, e1:Expr, e2:Expr):Dynamic {
 		var v;
 		switch (Tools.expr(e1)) {
 			case EIdent(id):
 				var l = locals.get(id);
 				v = fop(expr(e1), expr(e2));
 				if (l == null) {
-					if (__instanceFields.contains(id)) {
-						Reflect.setProperty(scriptObject, id, v);
-					} else if (__instanceFields.contains('set_$id')) { // setter
-						Reflect.getProperty(scriptObject, 'set_$id')(v);
+					if(hasScriptObject && !varExists(id)) {
+						var instanceHasField = __instanceFields.contains(id);
+
+						if (_scriptObjectType == SObject && instanceHasField) {
+							UnsafeReflect.setField(scriptObject, id, v);
+							return v;
+						} else if((_scriptObjectType == SCustomClass && instanceHasField) || _scriptObjectType == SAccessBehaviourObject) {
+							var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+							if(isBypassAccessor) {
+								obj.__allowSetGet = false;
+								var res = obj.hset(id, v);
+								obj.__allowSetGet = true;
+								return res;
+							}
+							return obj.hset(id, v);
+						}
+						else if (_scriptObjectType == SBehaviourClass) {
+							var obj:IHScriptCustomBehaviour = cast scriptObject;
+							return obj.hset(id, v);
+						}
+
+						if (instanceHasField) {
+							if(isBypassAccessor) {
+								UnsafeReflect.setField(scriptObject, id, v);
+								return v;
+							} else {
+								UnsafeReflect.setProperty(scriptObject, id, v);
+								return UnsafeReflect.field(scriptObject, id);
+							}
+						} else if (__instanceFields.contains('set_$id')) { // setter
+							return UnsafeReflect.getProperty(scriptObject, 'set_$id')(v);
+						} else {
+							setVar(id, v);
+						}
 					} else {
+						var obj = resolve(id, true, false);
+						if (obj != null && obj is Property) {
+							var prop:Property = cast obj;
+							return prop.callSetter(id, v);
+						}
 						setVar(id, v);
 					}
 				}
-				else
+				else {
+					var l = locals.get(id);
+					if (l.r is Property) {
+						var prop:Property = cast l.r;
+						return prop.callSetter(id, v);
+					}
 					l.r = v;
+					if (l.depth == 0) {
+						setVar(id, v);
+					}
+				}
 			case EField(e, f, s):
 				var obj = expr(e);
 				if(s && obj == null) return null;
@@ -295,8 +429,10 @@ class Interp {
 				var arr:Dynamic = expr(e);
 				var index:Dynamic = expr(index);
 				if (isMap(arr)) {
-					v = fop(getMapValue(arr, index), expr(e2));
-					setMapValue(arr, index, v);
+					var map = getMap(arr);
+
+					v = fop(map.get(index), expr(e2));
+					map.set(index, v);
 				} else {
 					v = fop(arr[index], expr(e2));
 					arr[index] = v;
@@ -315,18 +451,49 @@ class Interp {
 		switch (e) {
 			case EIdent(id):
 				var l = locals.get(id);
-				var v:Dynamic = (l == null) ? resolve(id) : l.r;
-				if (prefix) {
-					v += delta;
-					if (l == null)
-						setVar(id, v)
-					else
-						l.r = v;
-				} else if (l == null)
-					setVar(id, v + delta)
-				else
-					l.r = v + delta;
-				return v;
+				if(l != null) {
+					var v:Dynamic = l.r;
+					var prop:Property = null;
+					if (v is Property) {
+						prop = cast v;
+						v = prop.callGetter(id);
+					}
+
+					if (prefix) {
+						v += delta;
+						if (prop != null)
+							prop.callSetter(id, v);
+						else
+							l.r = v;
+					} else {
+						if (prop != null)
+							prop.callSetter(id, v + delta);
+						else
+							l.r = v + delta;
+					}
+					return v;
+				} else {
+					var v:Dynamic = resolve(id, true, false);
+					var prop:Property = null;
+					if (v is Property) {
+						prop = cast v;
+						v = prop.callGetter(id);
+					}
+
+					if (prefix) {
+						v += delta;
+						if (prop != null)
+							prop.callSetter(id, v);
+						else
+							setVar(id, v);
+					} else {
+						if (prop != null)
+							prop.callSetter(id, v + delta);
+						else
+							setVar(id, v + delta);
+					}
+					return v;
+				}
 			case EField(e, f, s):
 				var obj = expr(e);
 				if(s && obj == null) return null;
@@ -341,12 +508,14 @@ class Interp {
 				var arr:Dynamic = expr(e);
 				var index:Dynamic = expr(index);
 				if (isMap(arr)) {
-					var v = getMapValue(arr, index);
+					var map = getMap(arr);
+
+					var v = map.get(index);
 					if (prefix) {
 						v += delta;
-						setMapValue(arr, index, v);
+						map.set(index, v);
 					} else {
-						setMapValue(arr, index, v + delta);
+						map.set(index, v + delta);
 					}
 					return v;
 				} else {
@@ -365,14 +534,12 @@ class Interp {
 
 	public function execute(expr:Expr):Dynamic {
 		depth = 0;
-		#if haxe3
 		locals = new Map();
-		#else
-		locals = new Hash();
-		#end
-		declared = new Array();
+		declared = [];
 		return exprReturn(expr);
 	}
+
+	public var printCallStack:Bool = false;
 
 	function exprReturn(e):Dynamic {
 		try {
@@ -390,7 +557,10 @@ class Interp {
 						return v;
 				}
 			} catch(e) {
-				error(ECustom('${e.toString()}'));
+				if(printCallStack)
+					error(ECustom('${e.toString()}\n${CallStack.toString(CallStack.exceptionStack(true))}'));
+				else
+					error(ECustom(e.toString()));
 				return null;
 			}
 		} catch(e:Error) {
@@ -405,18 +575,19 @@ class Interp {
 		return null;
 	}
 
-	public function duplicate<T>(h:#if haxe3 Map<String, T> #else Hash<T> #end) {
-		#if haxe3
+	public function duplicate<T>(h:Map<String, T>) {
 		var h2 = new Map();
-		#else
-		var h2 = new Hash();
-		#end
-		for (k in h.keys())
+		var keys = h.keys();
+		var _hasNext = keys.hasNext;
+		var _next = keys.next;
+		while (_hasNext()) {
+			var k = _next();
 			h2.set(k, h.get(k));
+		}
 		return h2;
 	}
 
-	function restore(old:Int) {
+	function restore(old:Int):Void {
 		while (declared.length > old) {
 			var d = declared.pop();
 			locals.set(d.n, d.old);
@@ -426,15 +597,24 @@ class Interp {
 	public inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic {
 		#if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
 
-		if (rethrow) {
+		if (rethrow)
 			this.rethrow(e);
-		} else {
+		else
 			throw e;
-		}
+		
 		return null;
 	}
 
-	inline function rethrow(e:Dynamic) {
+	public inline function warn(e:#if hscriptPos ErrorDef #else Error #end) {
+		#if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+
+		if(warnHandler != null)
+			warnHandler(e);
+		else
+			trace('[ Warning ] ${Printer.errorToString(e)}');
+	}
+
+	inline function rethrow(e:Dynamic):Void {
 		#if hl
 		hl.Api.rethrow(e);
 		#else
@@ -442,36 +622,91 @@ class Interp {
 		#end
 	}
 
-	public function resolve(id:String, doException:Bool = true):Dynamic {
+	public function resolve(id:String, doException:Bool = true, allowProperty:Bool = true):Dynamic {
 		if (id == null)
 			return null;
 		id = StringTools.trim(id);
-		var l = locals.get(id);
-		if (l != null)
-			return l.r;
 
-		var v = variables.get(id);
-		for(map in [variables, publicVariables, staticVariables, customClasses])
-			if (map.exists(id))
-				return map[id];
+		if(inCustomClass && id == 'super') {
+			var customClass:IHScriptCustomClassBehaviour = cast scriptObject;
+			var superClass = customClass.hget('superClass');
+			return superClass == null ? customClass.hget('superConstructor') : superClass;
+		}
 
-		if (scriptObject != null) {
+		if (locals.exists(id)) {
+			var l = locals.get(id);
+			if(l != null) {
+				if(l.r != null && l.r is Property && allowProperty)  
+					return cast(l.r, Property).callGetter(id);
+				else 
+					return l.r;
+			}
+		}
+
+		for(map in [variables, publicVariables, staticVariables]) {
+			if(map.exists(id)) {
+				var r:Null<Dynamic> = map.get(id);
+				if(r != null && r is Property && allowProperty) 
+					return cast(r, Property).callGetter(id);
+				else 
+					return r;
+			}
+		}
+
+		if(customClasses.exists(id))
+			return customClasses.get(id);
+
+		if (hasScriptObject) {
 			// search in object
 			if (id == "this") {
 				return scriptObject;
-			} else if ((Type.typeof(scriptObject) == TObject) && Reflect.hasField(scriptObject, id)) {
-				return Reflect.field(scriptObject, id);
-			} else {
-				if (__instanceFields.contains(id)) {
-					return Reflect.getProperty(scriptObject, id);
-				} else if (__instanceFields.contains('get_$id')) { // getter
-					return Reflect.getProperty(scriptObject, 'get_$id')();
+			}
+			var instanceHasField = __instanceFields.contains(id);
+
+			if (_scriptObjectType == SObject && instanceHasField) {
+				return UnsafeReflect.field(scriptObject, id);
+			} else if((_scriptObjectType == SCustomClass && instanceHasField) || _scriptObjectType == SAccessBehaviourObject) {
+				var obj:IHScriptCustomAccessBehaviour = cast scriptObject;
+				if(isBypassAccessor) {
+					obj.__allowSetGet = false;
+					var res = obj.hget(id);
+					obj.__allowSetGet = true;
+					return res;
 				}
+				return obj.hget(id);
+			} else if(_scriptObjectType == SBehaviourClass) {
+				var obj:IHScriptCustomBehaviour = cast scriptObject;
+				return obj.hget(id);
+			}
+
+			if (instanceHasField) {
+				if(isBypassAccessor) {
+					return UnsafeReflect.field(scriptObject, id);
+				} else {
+					return UnsafeReflect.getProperty(scriptObject, id);
+				}
+			} else if (__instanceFields.contains('get_$id')) { // getter
+				return UnsafeReflect.getProperty(scriptObject, 'get_$id')();
 			}
 		}
 		if (doException)
 			error(EUnknownVariable(id));
-		return v;
+		return null;
+	}
+
+	public static var importRedirects:Map<String, String> = new Map();
+	public static function getImportRedirect(className:String):String {
+		return importRedirects.exists(className) ? importRedirects.get(className) : className;
+	}
+
+	public var localImportRedirects:Map<String, String> = new Map();
+	public function getLocalImportRedirect(className:String):String {
+		var className = className;
+		if (importRedirects.exists(className))
+			className = importRedirects.get(className);
+		if (localImportRedirects.exists(className))
+			className = localImportRedirects.get(className);
+		return className;
 	}
 
 	public function expr(e:Expr):Dynamic {
@@ -480,9 +715,18 @@ class Interp {
 		var e = e.e;
 		#end
 		switch (e) {
-			case EClass(name, fields, extend, interfaces):
-				if (customClasses.exists(name))
-					error(EAlreadyExistingClass(name));
+			case EPackage(_):
+			case EClass(name, fields, extend, interfaces, isFinal):
+				// TODO: module isolation
+				var oldName:String = name;
+				var hasAlias:Bool = (setAlias != null && beforeAlias == oldName);
+				var toSetName:String = hasAlias ? setAlias : oldName;
+
+				//if(customClasses.exists(toSetName)) error(EAlreadyExistingClass(toSetName));
+				if(customClasses.exists(toSetName)) {
+					warn(EAlreadyExistingClass(toSetName));
+					return null; // ignore it
+				}
 
 				inline function importVar(thing:String):String {
 					if (thing == null)
@@ -490,97 +734,230 @@ class Interp {
 					final variable:Class<Any> = variables.exists(thing) ? cast variables.get(thing) : null;
 					return variable == null ? thing : Type.getClassName(variable);
 				}
-				customClasses.set(name, new CustomClassHandler(this, name, fields, importVar(extend), [for (i in interfaces) importVar(i)]));
-			case EImport(c, n):
-				if (!importEnabled)
-					return null;
-				var splitClassName = [for (e in c.split(".")) e.trim()];
+				var cls:CustomClassHandler = new CustomClassHandler(this, oldName, fields, importVar(extend), [for (i in interfaces) importVar(i)], isFinal);
+				customClasses.set(toSetName, cls);
+				if(hasAlias) {
+					customClasses.set(oldName, cls); // Allow usage in the same module
+					beforeAlias = null;
+					setAlias = null;
+				}
+			case EImport(clsName, aliasAs, isUsing):
+				if(!importEnabled) return null;
+
+				var splitClassName = [for (e in clsName.split(".")) e.trim()];
 				var realClassName = splitClassName.join(".");
 				var claVarName = splitClassName[splitClassName.length - 1];
-				var toSetName = n != null ? n : claVarName;
+				var toSetName = aliasAs != null ? aliasAs : claVarName;
 				var oldClassName = realClassName;
 				var oldSplitName = splitClassName.copy();
 
-				if (variables.exists(toSetName)) // class is already imported
-					return null;
+				if(variables.exists(toSetName)) { // class is already imported 
+					if(isUsing && !usingHandler.entryExists(toSetName))
+						setUsing(toSetName, variables.get(toSetName)); 
 
-				if (importBlocklist.contains(realClassName))
 					return null;
-				var cl = Type.resolveClass(realClassName);
-				if (cl == null)
-					cl = Type.resolveClass('${realClassName}_HSC');
+				}
 
+				if(customClasses.exists(toSetName)) { // custom class is already parsed and imported 
+					// NOTE: you will need to create/import 
+					// the custom class first before
+					// setting the extension
+					if(isUsing && !usingHandler.entryExists(toSetName))
+						setCustomClassUsing(toSetName, customClasses.get(toSetName));
+
+					return null;
+				}
+
+				function importResolve(__clsName:String):Null<Dynamic> {
+					var _realClassName = getLocalImportRedirect(__clsName);
+					if(importBlocklist.contains(_realClassName)) return null;
+
+					var _cl = Type.resolveClass(_realClassName);
+					if(_cl == null) _cl = Type.resolveClass('${_realClassName}_HSC');
+					return _cl;
+				}
+
+				var cl = importResolve(realClassName);
 				var en = Type.resolveEnum(realClassName);
-
 				//trace(realClassName, cl, en, splitClassName);
 
 				// Allow for flixel.ui.FlxBar.FlxBarFillDirection;
-				if (cl == null && en == null) {
+				if(cl == null && en == null) {
 					if(splitClassName.length > 1) {
 						splitClassName.splice(-2, 1); // Remove the last last item
 						realClassName = splitClassName.join(".");
 
-						if (importBlocklist.contains(realClassName))
-							return null;
-
-						cl = Type.resolveClass(realClassName);
-						if (cl == null)
-							cl = Type.resolveClass('${realClassName}_HSC');
-
+						cl = importResolve(realClassName);
 						en = Type.resolveEnum(realClassName);
-
 						//trace(realClassName, cl, en, splitClassName);
 					}
 				}
 
-				if (cl == null && en == null) {
-					if (importFailedCallback == null || !importFailedCallback(oldSplitName))
+				if(cl == null && en == null) {
+					if(allowStaticImports) { //allows for static imports like "haxe.io.Path.normalize"
+						var clPth = oldSplitName.copy();
+						var funcName = clPth.pop();
+						var statField = Reflect.getProperty(Type.resolveClass(StringTools.trim(clPth.join("."))), funcName);
+
+						if(statField != null) {
+							variables.set((toSetName != null && toSetName.length > 0 ? toSetName : funcName), statField);
+							return null;
+						}
+					}
+
+					beforeAlias = claVarName;
+					setAlias = aliasAs;
+					if(importFailedCallback == null || !importFailedCallback(oldSplitName, toSetName)){
+						beforeAlias = null;
+						setAlias = null;
 						error(EInvalidClass(oldClassName));
+					}
 				} else {
-					if (en != null) {
-						// ENUM!!!!
-						var enumThingy = {};
-						for (c in en.getConstructors()) {
+					//If the first letter of the alias is not an uppercase letter, then throw an error.
+					//We don't need to worry about this for static imports.
+					if(toSetName != claVarName && !Tools.isUppercase(toSetName)) {
+						error(ECustom("Type aliases must start with an uppercase letter"));
+						return null;
+					}
+
+					if(en != null) { // ENUM!!!!
+						//if(isUsing) error(EInvalidClass(oldClassName));
+						if(isUsing) {
+							error(EInvalidClass(oldClassName));
+							return null;
+						}
+
+						var enumThingy:HEnum = {};
+						for(c in en.getConstructors()) {
 							try {
-								Reflect.setField(enumThingy, c, en.createByName(c));
+								//UnsafeReflect.setField(enumThingy, c, en.createByName(c));
+								enumThingy.setEnum(c, en.createByName(c));
 							} catch(e) {
 								try {
-									Reflect.setField(enumThingy, c, Reflect.field(en, c));
+									//UnsafeReflect.setField(enumThingy, c, UnsafeReflect.field(en, c));
+									enumThingy.setEnum(c, UnsafeReflect.field(en, c));
 								} catch(ex) {
 									throw e;
 								}
 							}
 						}
 						variables.set(toSetName, enumThingy);
-					} else {
+					} else { //Standard class
+						if(isUsing) setUsing(toSetName, cl);
 						variables.set(toSetName, cl);
 					}
 				}
-
 				return null;
 
+			case EEnum(en, _): // TODO: enum abstracts
+				var enumThingy:HEnum = {};
+				var enumName = en.name;
+				var enumFields = en.fields;
+				for (i => ef in enumFields) {
+					var fieldName = ef.name;
+					
+					if(ef.args.length < 1) {
+						var enumValue:HEnumValue = {
+							enumName: enumName,
+							fieldName: fieldName,
+							index: i,
+							args: []
+						}
+
+						enumThingy.setEnum(fieldName, enumValue);
+					}
+					else {
+						var params = ef.args;
+						var hasOpt = false, minParams = 0;
+						for (p in params) {
+							if (p.opt)
+								hasOpt = true;
+							else
+								minParams++;
+						}
+							
+						var f = function(args:Array<Dynamic>):HEnumValue {
+							if (((args == null) ? 0 : args.length) != params.length) {
+								if (args.length < minParams) {
+									var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
+									if (enumName != null)
+										str += " for enum '" + enumName + "'";
+									error(ECustom(str));
+								}
+								// make sure mandatory args are forced
+								var args2 = [];
+								var extraParams = args.length - minParams;
+								var pos = 0;
+								for (p in params)
+									if (p.opt) {
+										if (extraParams > 0) {
+											args2.push(args[pos++]);
+											extraParams--;
+										} else
+											args2.push(null);
+									} else
+										args2.push(args[pos++]);
+								args = args2;
+							}
+							return {
+								enumName: enumName,
+								fieldName: fieldName,
+								index: i,
+								args: args
+							};
+						};
+						var f = Reflect.makeVarArgs(f);
+
+						enumThingy.setEnum(fieldName, f);
+					}
+				}
+
+				variables.set(en.name, enumThingy);
+			case ECast(e, _): // TODO
+				return expr(e);
+			case ERegex(e, f):
+				return new EReg(e, f);
 			case EConst(c):
 				switch (c) {
 					case CInt(v): return v;
 					case CFloat(f): return f;
 					case CString(s): return s;
-					#if !haxe3
-					case CInt32(v): return v;
-					#end
 				}
 			case EIdent(id):
 				return resolve(id);
-			case EVar(n, _, e, isPublic, isStatic):
+			case EVar(n, _, e, isPublic, isStatic, _, isFinal, _, getter, setter, isVar):
+				var hasGetSet:Bool = (getter != null || setter != null);
+				if(depth > 0 && hasGetSet) {
+					error(ECustom("Property Accessor for local variables is not allowed"));
+					return null;
+				}
 				declared.push({n: n, old: locals.get(n), depth: depth});
-				locals.set(n, {r: (e == null) ? null : expr(e), depth: depth});
-				if (depth == 0) {
-					if(isStatic == true) {
-						if(!staticVariables.exists(n)) {
-							staticVariables.set(n, locals[n].r);
-						}
-						return null;
+				var r:Dynamic = (e == null) ? null : expr(e);
+				var declProp:Property = null;
+				if (hasGetSet) {
+					declProp = {
+						r: r,
+						getter: getter,
+						setter: setter,
+						isVar: isVar,
+						isStatic: isStatic,
+						interp: this,
 					}
-					(isPublic ? publicVariables : variables).set(n, locals[n].r);
+				}
+				var declVar:DeclaredVar = {
+					r: (declProp == null) ? r : declProp,
+					depth: depth
+				};
+				locals.set(n, declVar);
+				if (depth == 0) {
+					if(allowStaticVariables && isStatic == true) {
+						if(!staticVariables.exists(n)) // make it so it only sets it once
+							staticVariables.set(n, locals[n].r);
+					} else if(allowPublicVariables && isPublic == true) {
+						publicVariables.set(n, locals[n].r);
+					} else {
+						variables.set(n, locals[n].r);
+					}
 				}
 				return null;
 			case EParent(e):
@@ -613,18 +990,12 @@ class Interp {
 					case "--":
 						return increment(e, prefix, -1);
 					case "~":
-						#if (neko && !haxe3)
-						return haxe.Int32.complement(expr(e));
-						#else
 						return ~expr(e);
-						#end
 					default:
 						error(EInvalidOp(op));
 				}
 			case ECall(e, params):
-				var args = new Array();
-				for (p in params)
-					args.push(expr(p));
+				var args:Array<Dynamic> = makeArgs(params);
 
 				switch (Tools.expr(e)) {
 					case EField(e, f, s):
@@ -655,12 +1026,19 @@ class Interp {
 			case EReturn(e):
 				returnValue = e == null ? null : expr(e);
 				throw SReturn;
-			case EFunction(params, fexpr, name, _, isPublic, isStatic, isOverride):
+			case EFunction(params, fexpr, name, _, isPublic, isStatic, isOverride, isPrivate, isFinal, isInline):
 				var __capturedLocals = duplicate(locals);
-				var capturedLocals:Map<String, {r:Dynamic, depth:Int}> = [];
-				for(k=>e in __capturedLocals)
+				var capturedLocals:Map<String, DeclaredVar> = [];
+
+				var keys = __capturedLocals.keys();
+				var _hasNext = keys.hasNext;
+				var _next = keys.next;
+				while (_hasNext()) {
+					var k = _next();
+					var e = __capturedLocals.get(k);
 					if (e != null && e.depth > 0)
 						capturedLocals.set(k, e);
+				}
 
 				var me = this;
 				var hasOpt = false, minParams = 0;
@@ -724,11 +1102,17 @@ class Interp {
 				if (name != null) {
 					if (depth == 0) {
 						// global function
-						((isStatic && allowStaticVariables) ? staticVariables : ((isPublic && allowPublicVariables) ? publicVariables : variables)).set(name, f);
+						if(isStatic && allowStaticVariables) {
+							staticVariables.set(name, f);
+						} else if(isPublic && allowPublicVariables) {
+							publicVariables.set(name, f);
+						} else {
+							variables.set(name, f);
+						}
 					} else {
 						// function-in-function is a local function
 						declared.push({n: name, old: locals.get(name), depth: depth});
-						var ref = {r: f, depth: depth};
+						var ref:DeclaredVar = {r: f, depth: depth};
 						locals.set(name, ref);
 						capturedLocals.set(name, ref); // allow self-recursion
 					}
@@ -736,13 +1120,22 @@ class Interp {
 				return f;
 			case EArrayDecl(arr, wantedType):
 				var isMap = false;
-				var isTypeMap = false;
-				if(!isMap && wantedType != null) {
-					isMap = wantedType.match(CTPath(["Map"], [_, _]));
-					isTypeMap = true;
-				} else {
-					isMap = arr.length > 0 && Tools.expr(arr[0]).match(EBinop("=>", _));
+
+				if (wantedType != null) {
+					isMap = switch (wantedType) {
+						case CTPath(["Map"], [_, _]): true;
+						case CTPath(["StringMap"], [_]): true;
+						case CTPath(["IntMap"], [_]): true;
+						case CTPath(["ObjectMap"], [_]): true;
+						case CTPath(["EnumMap"], [_]): true;
+						default: false;
+					};
 				}
+
+				if (!isMap && arr.length > 0) {
+					isMap = Tools.expr(arr[0]).match(EBinop("=>", _));
+				}
+
 				if (isMap) {
 					var isAllString:Bool = true;
 					var isAllInt:Bool = true;
@@ -750,9 +1143,10 @@ class Interp {
 					var isAllEnum:Bool = true;
 					var keys:Array<Dynamic> = [];
 					var values:Array<Dynamic> = [];
+
 					for (e in arr) {
 						switch (Tools.expr(e)) {
-							case EBinop("=>", eKey, eValue): {
+							case EBinop("=>", eKey, eValue):
 								var key:Dynamic = expr(eKey);
 								var value:Dynamic = expr(eValue);
 								isAllString = isAllString && (key is String);
@@ -761,23 +1155,28 @@ class Interp {
 								isAllEnum = isAllEnum && Reflect.isEnumValue(key);
 								keys.push(key);
 								values.push(value);
-							}
-							default: throw("=> expected");
+							default:
+								throw "=> expected";
 						}
 					}
 
-					if(isTypeMap) {
-						if(wantedType != null) {
-							isAllString = wantedType.match(CTPath(["Map"], [CTPath(["String"], _), _]));
-							isAllInt = wantedType.match(CTPath(["Map"], [CTPath(["Int"], _), _]));
-							if(isAllString || isAllInt) {
-								isAllObject = false;
-								isAllEnum = false;
-							} else {
-								if(!isAllObject && !isAllEnum) {
-									throw("Unknown Type Key");
-								}
-							}
+					if (wantedType != null) {
+						isAllString = isAllString && (
+							wantedType.match(CTPath(["Map"], [CTPath(["String"], _), _])) || wantedType.match(CTPath(["StringMap"], [_]))
+						);
+						isAllInt = isAllInt && (
+							wantedType.match(CTPath(["Map"], [CTPath(["Int"], _), _])) || wantedType.match(CTPath(["IntMap"], [_]))
+						);
+						isAllObject = isAllObject && (
+							wantedType.match(CTPath(["Map"], [CTPath(["Dynamic"], _), _])) || wantedType.match(CTPath(["ObjectMap"], [_, _]))
+						);
+						isAllEnum = isAllEnum && (
+							wantedType.match(CTPath(["Map"], [CTPath(["Enum"], _), _])) || wantedType.match(CTPath(["EnumMap"], [_, _]))
+						);
+
+						if (!isAllString && !isAllInt && !isAllObject && !isAllEnum) {
+							isAllObject = true; // Assume dynamic
+							//throw "Unknown Type Key";
 						}
 					}
 
@@ -791,14 +1190,14 @@ class Interp {
 						else if (isAllObject)
 							new haxe.ds.ObjectMap<Dynamic, Dynamic>();
 						else
-							throw 'Inconsistent key types';
+							throw 'Unknown Type Key';
 					}
 					for (n in 0...keys.length) {
 						setMapValue(map, keys[n], values[n]);
 					}
 					return map;
 				} else {
-					var a = new Array();
+					var a = [];
 					for (e in arr) {
 						a.push(expr(e));
 					}
@@ -812,10 +1211,8 @@ class Interp {
 				} else {
 					return arr[index];
 				}
-			case ENew(cl, params):
-				var a = new Array();
-				for (e in params)
-					a.push(expr(e));
+			case ENew(cl, params, _):
+				var a:Array<Dynamic> = makeArgs(params);
 				return cnew(cl, a);
 			case EThrow(e):
 				throw expr(e);
@@ -845,19 +1242,60 @@ class Interp {
 			case EObject(fl):
 				var o = {};
 				for (f in fl)
-					set(o, f.name, expr(f.e));
+					UnsafeReflect.setField(o, f.name, expr(f.e));
 				return o;
 			case ETernary(econd, e1, e2):
 				return if (expr(econd) == true) expr(e1) else expr(e2);
 			case ESwitch(e, cases, def):
+				var old = declared.length;
 				var val:Dynamic = expr(e);
 				var match = false;
 				for (c in cases) {
-					for (v in c.values)
-						if (expr(v) == val) {
-							match = true;
-							break;
+					for (v in c.values) {
+						// https://github.com/FunkinCrew/hscript/blob/funkin-dev/hscript/Interp.hx#L611
+						switch (Tools.expr(v)) {
+							case ECall(e, params):
+								switch (Tools.expr(e)) {
+									case EField(_, f):
+										var isScripted:Bool = val is HEnumValue;
+										var valStr:String = '';
+										var valEnum:HEnumValue = null;
+										if(isScripted)  {
+											valEnum = cast val;
+											valStr = valEnum.fieldName;
+										}
+										else {
+											valStr = cast val;
+											valStr = valStr.substring(0, valStr.indexOf("("));
+										}
+
+										if(valStr == f) {
+											var valParams = isScripted ? valEnum.getConstructorArgs() : Type.enumParameters(val);
+											for (i => p in params) {
+												switch (Tools.expr(p)) {
+													case EIdent(n):
+														declared.push({
+															n: n,
+															old: {r: locals.get(n), depth: depth},
+															depth: depth
+														});
+														locals.set(n, {r: valParams[i], depth: depth});
+													default:
+												}
+											}
+											match = true;
+											break;
+										}
+									default:
+								}
+							default:
+								if (expr(v) == val) {
+									match = true;
+									break;
+								}
 						}
+					}
+					
 					if (match) {
 						val = expr(c.expr);
 						break;
@@ -865,16 +1303,22 @@ class Interp {
 				}
 				if (!match)
 					val = def == null ? null : expr(def);
+				restore(old);
 				return val;
 			case EMeta(name, args, e):
-				if (name != ":bypassAccessor" && onMetadata != null) return onMetadata(name, args, e);
-				var oldAccessor = isBypassAccessor;
-				if(name == ":bypassAccessor") {
-					isBypassAccessor = true;
+				var val:Dynamic = null;
+				switch(name) {
+					case ":bypassAccessor":
+						var oldAccessor = isBypassAccessor;
+						isBypassAccessor = true;
+						val = expr(e);
+						isBypassAccessor = oldAccessor;
+						return val;
+					default:
+						if(onMetadata != null) return onMetadata(name, args, e);
 				}
-				var val = expr(e);
 
-				isBypassAccessor = oldAccessor;
+				val = expr(e);
 				return val;
 			case ECheckType(e, _):
 				return expr(e);
@@ -882,186 +1326,339 @@ class Interp {
 		return null;
 	}
 
-	function doWhileLoop(econd, e) {
+	function doWhileLoop(econd:Expr, e:Expr):Void {
 		var old = declared.length;
 		do {
-			try {
-				expr(e);
-			} catch (err:Stop) {
-				switch (err) {
-					case SContinue:
-					case SBreak:
-						break;
-					case SReturn:
-						throw err;
-				}
-			}
+			if (!loopRun(() -> expr(e)))
+				break;
 		} while (expr(econd) == true);
 		restore(old);
 	}
 
-	function whileLoop(econd, e) {
+	function whileLoop(econd:Expr, e:Expr):Void {
 		var old = declared.length;
 		while (expr(econd) == true) {
-			try {
-				expr(e);
-			} catch (err:Stop) {
-				switch (err) {
-					case SContinue:
-					case SBreak:
-						break;
-					case SReturn:
-						throw err;
-				}
-			}
+			if (!loopRun(() -> expr(e)))
+				break;
 		}
 		restore(old);
 	}
 
 	function makeIterator(v:Dynamic, ?allowKeyValue = false):Iterator<Dynamic> {
-		#if ((flash && !flash9) || (php && !php7 && haxe_ver < '4.0.0'))
-		if (v.iterator != null)
+		#if js
+		// don't use try/catch (very slow)
+		if(v is Array) {
+			return allowKeyValue ? (v:Array<Dynamic>).keyValueIterator() : (v:Array<Dynamic>).iterator();
+		}
+		if(allowKeyValue && v.keyValueIterator != null)
+			v = v.keyValueIterator();
+		else if (v.iterator != null)
 			v = v.iterator();
 		#else
-		if(allowKeyValue) {
-			try
-				v = v.keyValueIterator()
-			catch (e:Dynamic) {};
-		}
+		if(allowKeyValue) 
+			try v = v.keyValueIterator() catch (e:Dynamic) {};
 
-		if(v.hasNext == null || v.next == null) {
-			try
-				v = v.iterator()
-			catch (e:Dynamic) {};
-		}
+		if(v.hasNext == null || v.next == null) 
+			try v = v.iterator() catch (e:Dynamic) {};
+		
 		#end
-		if (v.hasNext == null || v.next == null)
-			error(EInvalidIterator(v));
+		if (v.hasNext == null || v.next == null) error(EInvalidIterator(v));
 		return v;
 	}
 
-	function forLoop(n, it, e, ?ithv) {
+	function makeArgs(params:Array<Expr>):Array<Dynamic> {
+		var args:Array<Dynamic> = [];
+		for (p in params) {
+			switch (Tools.expr(p)) {
+				case EIdent(id):
+					var ident = resolve(id);
+					if (ident is CustomClass) {
+						var customClass:CustomClass = cast ident; // Pass the underlying superclass if exist
+						args.push(customClass.__superClass != null ? customClass.getSuperclass() : customClass);
+					} else {
+						args.push(ident);
+					}
+				default:
+					args.push(expr(p));
+			}
+		}
+
+		return args;
+	}
+
+	function forLoop(n:String, it:Expr, e:Expr, ?ithv:String):Void {
 		var isKeyValue = ithv != null;
 		var old = declared.length;
 		if(isKeyValue)
 			declared.push({n: ithv, old: locals.get(ithv), depth: depth});
 		declared.push({n: n, old: locals.get(n), depth: depth});
 		var it = makeIterator(expr(it), isKeyValue);
-		while (it.hasNext()) {
-			var next = it.next();
+		var _hasNext = it.hasNext;
+		var _next = it.next;
+		while (_hasNext()) {
+			var next = _next();
 			if(isKeyValue)
 				locals.set(ithv, {r: next.key, depth: depth});
 			locals.set(n, {r: isKeyValue ? next.value : next, depth: depth});
-			try {
-				expr(e);
-			} catch (err:Stop) {
-				switch (err) {
-					case SContinue:
-					case SBreak:
-						break;
-					case SReturn:
-						throw err;
-				}
-			}
+			if (!loopRun(() -> expr(e)))
+				break;
 		}
 		restore(old);
+	}
+
+	inline function loopRun(f:Void -> Void) {
+		var cont = true;
+		try {
+			f();
+		} catch (err:Stop) {
+			switch (err) {
+				case SContinue:
+				case SBreak:
+					cont = false;
+				case SReturn:
+					throw err;
+			}
+		}
+		return cont;
 	}
 
 	inline function isMap(o:Dynamic):Bool {
 		return (o is IMap);
 	}
 
+	inline function getMap(map:Dynamic):IMap<Dynamic, Dynamic> {
+		var map:IMap<Dynamic, Dynamic> = cast map;
+		return map;
+	}
+
 	inline function getMapValue(map:Dynamic, key:Dynamic):Dynamic {
-		return cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).get(key);
+		var map:IMap<Dynamic, Dynamic> = cast map;
+		return map.get(key);
 	}
 
 	inline function setMapValue(map:Dynamic, key:Dynamic, value:Dynamic):Void {
-		cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).set(key, value);
+		var map:IMap<Dynamic, Dynamic> = cast map;
+		map.set(key, value);
 	}
 
 	public static var getRedirects:Map<String, Dynamic->String->Dynamic> = [];
 	public static var setRedirects:Map<String, Dynamic->String->Dynamic->Dynamic> = [];
 
+	private static var _getRedirect:Dynamic->String->Dynamic;
+	private static var _setRedirect:Dynamic->String->Dynamic->Dynamic;
+
+	public var useRedirects:Bool = false;
+
+	static function getClassType(o:Dynamic, ?cls:Class<Any>):Null<String> {
+		return switch (Type.typeof(o)) {
+			case TNull: "Null";
+			case TInt: "Int";
+			case TFloat: "Float";
+			case TBool: "Bool";
+			case _:
+				if (cls == null)
+					cls = Type.getClass(o);
+				cls != null ? Type.getClassName(cls) : null;
+		};
+	}
+
 	function get(o:Dynamic, f:String):Dynamic {
 		if (o == null)
 			error(EInvalidAccess(f));
-		return {
-			var redirect:Dynamic->String->Dynamic = null;
-			var cls = Type.getClass(o);
-			var cl:Null<String> = switch (Type.typeof(o)) {
-				case TNull: "Null";
-				case TInt: "Int";
-				case TFloat: "Float";
-				case TBool: "Bool";
-				case _: cls != null ? Type.getClassName(cls) : null;
-			};
-			if (cl != null && getRedirects.exists(cl) && (redirect = getRedirects[cl]) != null) {
-				return redirect(o, f);
-			} else if (o is IHScriptCustomBehaviour) {
-				var obj = cast(o, IHScriptCustomBehaviour);
-				return obj.hget(f);
-			} else {
-				var v = null;
-				if(isBypassAccessor) {
-					if ((v = Reflect.field(o, f)) == null)
-						v = Reflect.field(cls, f);
-				}
 
-				if(v == null) {
-					if ((v = Reflect.getProperty(o, f)) == null)
-						v = Reflect.getProperty(cls, f);
-				}
-				return v;
-			}
+		var cls:Null<Class<Dynamic>> = useRedirects ? Type.getClass(o) : null;
+		if (useRedirects && {
+			var cl:Null<String> = getClassType(o, cls);
+			cl != null && getRedirects.exists(cl) && (_getRedirect = getRedirects[cl]) != null;
+		}) {
+			return _getRedirect(o, f);
 		}
+		
+		if (o is IHScriptCustomAccessBehaviour) {
+			var obj:IHScriptCustomAccessBehaviour = cast o;
+			if(isBypassAccessor) {
+				obj.__allowSetGet = false;
+				var res = obj.hget(f);
+				obj.__allowSetGet = true;
+				return res;
+			}
+			return obj.hget(f);
+		}
+
+		if (o is IHScriptCustomBehaviour) {
+			var obj:IHScriptCustomBehaviour = cast o;
+			return obj.hget(f);
+		}
+		var v:Null<Dynamic> = null;
+		if(isBypassAccessor) {
+			if ((v = UnsafeReflect.field(o, f)) == null && useRedirects)
+				v = Reflect.field(cls, f);
+		}
+
+		if(v == null) {
+			#if php
+			// https://github.com/HaxeFoundation/haxe/issues/4915
+			try {
+				if ((v = UnsafeReflect.getProperty(o, f)) == null && useRedirects)
+					v = Reflect.getProperty(cls, f);
+			}
+			catch(e:Dynamic) {
+				if ((v = UnsafeReflect.field(o, f)) == null && useRedirects)
+					v = Reflect.field(cls, f);
+			}
+			#else
+			if ((v = UnsafeReflect.getProperty(o, f)) == null && useRedirects)
+				v = Reflect.getProperty(cls, f);
+			#end
+		}
+		return v;
 	}
 
 	function set(o:Dynamic, f:String, v:Dynamic):Dynamic {
 		if (o == null)
 			error(EInvalidAccess(f));
 
-		var redirect:Dynamic->String->Dynamic->Dynamic = null;
-		var cls = Type.getClass(o);
-		var cl:Null<String> = switch (Type.typeof(o)) {
-			case TNull: "Null";
-			case TInt: "Int";
-			case TFloat: "Float";
-			case TBool: "Bool";
-			case _: cls != null ? Type.getClassName(cls) : null;
-		};
-		if (cl != null && setRedirects.exists(cl) && (redirect = setRedirects[cl]) != null)
-			return redirect(o, f, v);
-		else if (o is IHScriptCustomBehaviour) {
-			var obj = cast(o, IHScriptCustomBehaviour);
+		if (useRedirects && {
+			var cl:Null<String> = getClassType(o);
+			cl != null && setRedirects.exists(cl) && (_setRedirect = setRedirects[cl]) != null;
+		})
+			return _setRedirect(o, f, v);
+		
+		if (o is IHScriptCustomAccessBehaviour) {
+			var obj:IHScriptCustomAccessBehaviour = cast o;
+			if(isBypassAccessor) {
+				obj.__allowSetGet = false;
+				var res = obj.hset(f, v);
+				obj.__allowSetGet = true;
+				return res;
+			}
 			return obj.hset(f, v);
 		}
+
+		if (o is IHScriptCustomBehaviour) {
+			var obj:IHScriptCustomBehaviour = cast o;
+			return obj.hset(f, v);
+		}
+		// Can use unsafe reflect here, since we checked for null above
 		if(isBypassAccessor) {
-			Reflect.setField(o, f, v);
+			UnsafeReflect.setField(o, f, v);
 		} else {
-			Reflect.setProperty(o, f, v);
+			UnsafeReflect.setProperty(o, f, v);
 		}
 		return v;
 	}
 
-	function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic {
-		if(o == CustomClassHandler.staticHandler && scriptObject != null) {
-			return Reflect.callMethod(scriptObject, Reflect.field(scriptObject, "_HX_SUPER__" + f), args);
+	// STATIC EXTENSION ("USING")
+
+	// Real class static extension
+	function setUsing(name:String, obj:Dynamic) {
+		if (usingHandler.entryExists(name)) return;
+		if (UsingHandler.defaultExtension.exists(name)) {
+			var us:UsingEntry = UsingHandler.defaultExtension.get(name);
+			usingHandler.usingEntries.set(name, us);
+			return;
 		}
-		return call(o, get(o, f), args);
+		if (obj == null) error(ECustom("Unknown using class " + name));
+
+		var fn:Dynamic->String->Array<Dynamic>->Dynamic = null;
+		var fields:Array<String> = [];
+		var cls = obj;
+
+		switch (Type.typeof(cls)) {
+			case TClass(c):
+				fields = Type.getClassFields(c);
+			case TObject:
+				fields = Reflect.fields(cls);
+			default:
+				error(ECustom('$name is not a class'));
+		}
+
+		fn = function(o:Dynamic, f:String, args:Array<Dynamic>) {
+			var field = Reflect.field(cls, f);
+			if (!Reflect.isFunction(field))
+				return null;
+
+			// invalid if the function has no arguments
+			var totalArgs = Tools.argCount(field);
+			if (totalArgs == 0)
+				return null;
+
+			return UnsafeReflect.callMethodUnsafe(cls, field, [o].concat(args));
+		}
+
+		if(fn != null) usingHandler.registerEntry(name, fn, fields);
+	}
+
+	// Custom Class Static Extension
+	@:access(hscript.CustomClassHandler)
+	function setCustomClassUsing(name:String, cls:CustomClassHandler) {
+		if (usingHandler.entryExists(name)) return;
+
+		var fn:Dynamic->String->Array<Dynamic> -> Dynamic;
+		var customClass:CustomClassHandler = cls;
+		var fields:Array<String> = customClass.__staticFields.copy();
+
+		fn = function(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic {
+			var field:Dynamic = customClass.getField(f);
+			if (!Reflect.isFunction(field))
+				return null;
+			/*
+			var totalArgs:Int = Tools.argCount(field);
+			if (totalArgs == 0)
+				return null;
+			 */
+			return UnsafeReflect.callMethodUnsafe(null, field, [o].concat(args));
+		}
+
+		usingHandler.registerEntry(name, fn, fields);
+	}
+
+	function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic {
+		// Custom logic to handle super calls to prevent infinite recursion
+		if(inCustomClass) {
+			if (o == scriptObject.__superClass) {
+				if (scriptObject.__superClass is CustomClass)
+					return cast(scriptObject.__superClass, CustomClass).call(f, args, true);
+				else
+					return UnsafeReflect.callMethodUnsafe(scriptObject.__superClass, UnsafeReflect.field(scriptObject.__superClass, '_HX_SUPER__$f'), args);
+			}
+		}
+
+		if (usingHandler.usingEntries.iterator().hasNext()) { // If is not empty
+			var v:Dynamic = null;
+			for (n => us in usingHandler.usingEntries) {
+				if(us.hasField(f)) {
+					v = us.call(o, f, args);
+					if (v != null)
+						return v;
+				}
+			}
+		}
+
+		var func = get(o, f);
+		// Workaround for an HTML5-specific issue.
+		// https://github.com/HaxeFoundation/haxe/issues/11298
+		#if js
+		if (func == null && f == "contains") {
+			func = get(o, "includes");
+		}
+		#end
+
+		return call(o, func, args);
 	}
 
 	function call(o:Dynamic, f:Dynamic, args:Array<Dynamic>):Dynamic {
-		if(f == CustomClassHandler.staticHandler) {
-			return null;
-		}
-		return Reflect.callMethod(o, f, args);
+		return UnsafeReflect.callMethodSafe(o, f, args);
 	}
 
 	function cnew(cl:String, args:Array<Dynamic>):Dynamic {
-		var cl:String = cast cl;
 		var c:Dynamic = resolve(cl);
 		if (c == null)
 			c = Type.resolveClass(cl);
-		return (c is IHScriptCustomConstructor) ? cast(c, IHScriptCustomConstructor).hnew(args) : Type.createInstance(c, args);
+		if (c is IHScriptCustomConstructor) {
+			var c:IHScriptCustomConstructor = cast c;
+			return c.hnew(args);
+		} else
+			return Type.createInstance(c, args);
 	}
 }

--- a/source/hscript/Property.hx
+++ b/source/hscript/Property.hx
@@ -1,0 +1,128 @@
+package hscript;
+
+import hscript.utils.UnsafeReflect;
+import hscript.Interp;
+import hscript.Expr.FieldPropertyAccess;
+
+/**
+ * Special variable that handles 'getter/setter' function calls
+ * depending of the read/write access combination.
+ * 
+ * Example:
+ * ```haxe
+ * public var myvar(get, set):Int;
+ * var _myvar:Int = 10;
+ * 
+ * function get_myvar():Int {
+ *   return _myvar;
+ * }
+ * 
+ * function set_myvar(val:Int):Int {
+ *   if(val > 10) return _myvar = val;
+ *   return val;
+ * }
+ * ```
+ * 
+ * @see https://haxe.org/manual/class-field-property.html
+ */
+@:access(hscript.Interp)
+@:structInit
+class Property {
+	private static inline var GET = 'get_';
+	private static inline var SET = 'set_';
+
+	public var r:Dynamic;
+	public var getter:FieldPropertyAccess;
+	public var setter:FieldPropertyAccess;
+
+	public var isStatic(get, never):Bool;
+	function get_isStatic() {
+		return __isStatic && interp.allowStaticVariables;
+	}
+
+	var isVar:Bool;
+	var interp:Interp;
+
+	public function new(r:Dynamic, getter:FieldPropertyAccess, setter:FieldPropertyAccess, isVar:Bool, isStatic:Bool, interp:Interp) {
+		this.r = r;
+		this.getter = getter;
+		this.setter = setter;
+		this.isVar = isVar;
+		this.__isStatic = isStatic;
+		this.interp = interp;
+	}
+
+	var __allowReadAccess:Bool = false;
+	var __allowWriteAccess:Bool = false;
+	var __allowSetGet:Null<Bool> = null;
+	final __isStatic:Bool = false;
+
+	public function callGetter(name:String) {
+		switch (getter) {
+			case AGet | ADynamic:
+				var fName:String = '$GET$name';
+				if (!__allowReadAccess && (__allowSetGet != null && __allowSetGet || !interp.isBypassAccessor)) {
+					if (varExists(fName)) {
+						return callAccessor(fName);
+					} else
+						interp.error(ECustom('Method $fName required by property $name is missing'));
+				} else {
+					if ((setter == ADefault || setter == ANull) || isVar)
+						return r;
+					else
+						interp.error(ECustom('Field $name cannot be accessed because it is not a real variable${interp.isBypassAccessor ? '. Add @:isVar to enable it' : ''}'));
+				}
+			case ANever:
+				interp.error(ECustom('This expression cannot be accessed for reading'));
+			default:
+		}
+
+		return r;
+	}
+
+	public function callSetter(name:String, val:Dynamic) {
+		switch (setter) {
+			case ASet | ADynamic:
+				var fName:String = '$SET$name';
+				if (!__allowWriteAccess && (__allowSetGet != null && __allowSetGet || !interp.isBypassAccessor)) {
+					if (varExists(fName))
+						return callAccessor(fName, [val], true);
+					else
+						interp.error(ECustom('Method $fName required by property $name is missing'));
+				} else {
+					if ((getter == ADefault || getter == ANull) || isVar)
+						return r = val;
+					else
+						interp.error(ECustom('Field $name cannot be accessed because it is not a real variable${interp.isBypassAccessor ? '. Add @:isVar to enable it' : ''}'));
+				}
+			case ANever:
+				interp.error(ECustom('This expression cannot be accessed for writing'));
+			default:
+		}
+
+		return r = val;
+	}
+
+	private function callAccessor(f:String, ?args:Array<Dynamic>, isWrite:Bool = false):Dynamic {
+		var fn = isStatic ? interp.staticVariables.get(f) : interp.variables.get(f);
+		var rt:Dynamic = null;
+		if (fn != null && Reflect.isFunction(fn)) {
+			if (isWrite) __allowWriteAccess = true;
+			else __allowReadAccess = true;
+
+			rt = UnsafeReflect.callMethodUnsafe(null, fn, args == null ? [] : args);
+
+			if (isWrite) __allowWriteAccess = false;
+			else __allowReadAccess = false;
+
+			return rt;
+		} else
+			interp.error(ECustom('Method $f required by property ${f.substr(3)} is missing'));
+
+		return rt;
+	}
+
+	private function varExists(n:String) {
+		return isStatic ? interp.staticVariables.exists(n) : interp.variables.exists(n);
+	}
+}

--- a/source/hscript/Tools.hx
+++ b/source/hscript/Tools.hx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package hscript;
+import hscript.Expr;
+
+class Tools {
+
+	public static function iter( e : Expr, f : Expr -> Void ):Void {
+		switch( expr(e) ) {
+		case EConst(_), EIdent(_):
+		case EImport(c): f(e);
+		case EClass(_, e, _, _): for( a in e ) f(a);
+		case EVar(_, _, e): if( e != null ) f(e);
+		case EParent(e): f(e);
+		case EBlock(el): for( e in el ) f(e);
+		case EField(e, _): f(e);
+		case EBinop(_, e1, e2): f(e1); f(e2);
+		case EUnop(_, _, e): f(e);
+		case ECall(e, args): f(e); for( a in args ) f(a);
+		case EIf(c, e1, e2): f(c); f(e1); if( e2 != null ) f(e2);
+		case EWhile(c, e): f(c); f(e);
+		case EDoWhile(c, e): f(c); f(e);
+		case EFor(_, it, e): f(it); f(e);
+		case EBreak,EContinue:
+		case EFunction(_, e, _, _): f(e);
+		case EReturn(e): if( e != null ) f(e);
+		case EArray(e, i): f(e); f(i);
+		case EArrayDecl(el): for( e in el ) f(e);
+		case ENew(_,el): for( e in el ) f(e);
+		case EThrow(e): f(e);
+		case ETry(e, _, _, c): f(e); f(c);
+		case EObject(fl): for( fi in fl ) f(fi.e);
+		case ETernary(c, e1, e2): f(c); f(e1); f(e2);
+		case ESwitch(e, cases, def):
+			f(e);
+			for( c in cases ) {
+				for( v in c.values ) f(v);
+				f(c.expr);
+			}
+			if( def != null ) f(def);
+		case EMeta(name, args, e): if( args != null ) for( a in args ) f(a); f(e);
+		case ECheckType(e,_): f(e);
+		default:
+		}
+	}
+
+	public static function map( e : Expr, f : Expr -> Expr ):Expr {
+		var edef = switch( expr(e) ) {
+		case EConst(_), EIdent(_), EBreak, EContinue: expr(e);
+		case EVar(n, t, e, isPublic, isStatic, isPrivate): EVar(n, t, if( e != null ) f(e) else null, isPublic, isStatic, isPrivate);
+		case EParent(e): EParent(f(e));
+		case EBlock(el): EBlock([for( e in el ) f(e)]);
+		case EField(e, fi): EField(f(e),fi);
+		case EBinop(op, e1, e2): EBinop(op, f(e1), f(e2));
+		case EUnop(op, pre, e): EUnop(op, pre, f(e));
+		case ECall(e, args): ECall(f(e),[for( a in args ) f(a)]);
+		case EIf(c, e1, e2): EIf(f(c),f(e1),if( e2 != null ) f(e2) else null);
+		case EWhile(c, e): EWhile(f(c),f(e));
+		case EDoWhile(c, e): EDoWhile(f(c),f(e));
+		case EFor(v, it, e): EFor(v, f(it), f(e));
+		case EFunction(args, e, name, t, isPublic, isStatic, isOverride, isPrivate): EFunction(args, f(e), name, t, isPublic, isStatic, isOverride, isPrivate);
+		case EReturn(e): EReturn(if( e != null ) f(e) else null);
+		case EArray(e, i): EArray(f(e),f(i));
+		case EArrayDecl(el): EArrayDecl([for( e in el ) f(e)]);
+		case ENew(cl,el): ENew(cl,[for( e in el ) f(e)]);
+		case EThrow(e): EThrow(f(e));
+		case ETry(e, v, t, c): ETry(f(e), v, t, f(c));
+		case EObject(fl): EObject([for( fi in fl ) { name : fi.name, e : f(fi.e) }]);
+		case ETernary(c, e1, e2): ETernary(f(c), f(e1), f(e2));
+		case ESwitch(e, cases, def): ESwitch(f(e), [for( c in cases ) { values : [for( v in c.values ) f(v)], expr : f(c.expr) } ], def == null ? null : f(def));
+		case EMeta(name, args, e): EMeta(name, args == null ? null : [for( a in args ) f(a)], f(e));
+		case ECheckType(e,t): ECheckType(f(e), t);
+		case EImport(c): EImport(c);
+		case EClass(name, el, extend, interfaces): EClass(name, [for( e in el ) f(e)], extend, interfaces);
+		default: expr(e);
+		}
+		return mk(edef, e);
+	}
+
+	public static inline function expr( e : Expr ) : ExprDef {
+		#if hscriptPos
+		return e.e;
+		#else
+		return e;
+		#end
+	}
+
+	public static inline function mk( e : ExprDef, p : Expr ):Expr {
+		#if hscriptPos
+		return { e : e, pmin : p.pmin, pmax : p.pmax, origin : p.origin, line : p.line };
+		#else
+		return e;
+		#end
+	}
+
+	/**
+	 * DO NOT USE INLINE ON THIS FUNCTION
+	**/
+	public static function argCount(func: haxe.Constraints.Function): Int {
+		// https://github.com/pisayesiwsi/hscript-iris/blob/dev/crowplexus/hscript/Tools.hx#L206
+		#if cpp
+		return untyped __cpp__("{0}->__ArgCount()", func);
+		#elseif js
+		return untyped js.Syntax.code("{0}.length", func);
+		#elseif hl
+		var ft = hl.Type.getDynamic(func);
+		if (ft.kind != HFun)
+			return -1;
+		return ft.getArgsCount();
+		#else
+		return -1;
+		#end
+	}
+
+	public static function isUppercase(s:String) {
+		if(s.length == 0) return false;
+		var c:Int = StringTools.fastCodeAt(s, 0);
+		if(StringTools.isEof(c)) return false; // Just in case :3
+		return c >= 65 && c <= 90; // A-Z
+	}
+
+	public static inline function isCustomAbstract(obj:Dynamic):Bool
+		return obj != null && obj is IHScriptAbstractBehaviour;
+
+}

--- a/source/import.hx
+++ b/source/import.hx
@@ -74,5 +74,4 @@ import backend.Log.info;
 #else
 import haxe.Log;
 #end
-
 #end

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -1,24 +1,36 @@
 package psychlua;
 
+#if HSCRIPT_ALLOWED
 import hscript.Expr.Error;
 import hscript.Expr;
 import hscript.*;
+#end
 
 import flixel.FlxG;
+import flixel.FlxBasic;
 import flixel.util.FlxColor;
 import psychlua.LuaUtils;
 #if LUA_ALLOWED
 import llua.Lua;
 #end
+
+#if PRETTY_TRACE
+import backend.Log;
+#else
+import haxe.Log;
+#end
+
 #if sys
 import sys.io.File;
+import sys.FileSystem;
 #else
 import openfl.utils.Assets;
 #end
 
 /*
- * HScript improved class. Originally made for T-Bar Psych Fork & modified for use in Ghost Engine
-*/
+ * The class that handles haxe scripts. Based off of T-Bar Engine's HScript class & modified for use here!
+ */
+using StringTools;
 interface HscriptInterface {
     public var scriptName:String;
     public function set(variable:String, data:Dynamic):Void;
@@ -26,115 +38,124 @@ interface HscriptInterface {
     public function stop():Void;
 }
 
+#if HSCRIPT_ALLOWED
 class HScript implements HscriptInterface {
 
-    public static var classes:Map<String, Dynamic> = [ //All the default classes
-		//Haxe Classes
-        "Math" => Math,
-        "Std" => Std,
-		"Type" => Type,
+	/*
+	 * All the default classes pre-imported into every haxe script / runHaxeCode.
+	 * These variables are free to be edited to allow for custom pre-imported classes.
+	 */
+    public static var classes:Map<String, Dynamic> = [
+		//Base level haxe classes. Not recommended to edit these!
+		"Math" => Math, "Std" => Std,
 		"StringTools" => StringTools,
-		"Reflect" => Reflect,
-
-		//Flixel Classes
-        "FlxG" => flixel.FlxG,
-        "FlxSprite" => flixel.FlxSprite,
-        "FlxTimer" => flixel.util.FlxTimer,
-        "FlxTween" => flixel.tweens.FlxTween,
-        "FlxEase" => flixel.tweens.FlxEase,
-        "FlxText" => flixel.text.FlxText,
+		"Reflect" => Reflect, 'Type' => Type,
+		'Date' => Date, 'DateTools' => DateTools,
 		#if sys
-        "File" => sys.io.File,
-        "FileSystem" => sys.FileSystem,
+		'Sys' => Sys,
+		"File" => sys.io.File,
+		"FileSystem" => sys.FileSystem,
 		#end
 
+		//Flixel Classes
+		"FlxG" => flixel.FlxG,
+		"FlxSprite" => flixel.FlxSprite,
+		"FlxTimer" => flixel.util.FlxTimer,
+		"FlxTween" => flixel.tweens.FlxTween,
+		"FlxEase" => flixel.tweens.FlxEase,
+		"FlxText" => flixel.text.FlxText,
+
 		//Friday Night Funkin' Classes
-        "Paths" => backend.Paths,
-        "Conductor" => backend.Conductor,
-        "PlayState" => states.PlayState,
-        "Boyfriend" => objects.Character, //compatibility
-        "Character" => objects.Character,
-		"CoolUtil"	=> backend.CoolUtil,
-        "ClientPrefs" => backend.ClientPrefs,
 		"MusicBeatState" => backend.MusicBeatState,
 		"MusicBeatSubstate" => backend.MusicBeatSubstate,
+		"ClientPrefs" => backend.ClientPrefs,
+		"PlayState" => states.PlayState,
+		"Conductor" => backend.Conductor,
+		"Boyfriend" => objects.Character, //compatibility
+		"Character" => objects.Character,
+		"CoolUtil"	=> backend.CoolUtil,
+		"Paths" => backend.Paths,
+		#if PRETTY_TRACE
+		"Log" => backend.Log,
+		#end
 		"Global" => backend.Global,
-
-		//Classes in the root folder are pre-added so you don't have to do `import Main;`
+		"KeyValueArray" => Types.KeyValueArray,
 		"Main" => Main,
 
 		//Extras
-		"Json" => { //Using the base haxe.Json library produces a null function pointer
+		"Json" => { //Using the base Json library produces a null function pointer
 			parse: function(txt:String):Dynamic { return haxe.Json.parse(txt); },
 			stringify: function(value:Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String) { return haxe.Json.stringify(value, replacer, space); }
 		},
 		"FlxBasic" => flixel.FlxBasic,
 		"FlxCamera" => flixel.FlxCamera,
-		"FlxSound" => flixel.sound.FlxSound, //Not like people will use the old flixel for flixel.sytem
 		"FlxMath" => flixel.math.FlxMath,
 		"FlxGroup" => flixel.group.FlxGroup,
-		#if (!flash) "FlxRuntimeShader" => flixel.addons.display.FlxRuntimeShader, #end
+		"FlxTypedGroup" => flixel.group.FlxGroup.FlxTypedGroup,
+		"FlxSpriteGroup" => flixel.group.FlxSpriteGroup,
+		"FlxSound" => #if(flixel >= "5.3.0") flixel.sound.FlxSound #else flixel.system.FlxSound #end,
+		#if(flxanimate) "FlxAnimate" => flxanimate.FlxAnimate, #end
+		#if(!flash) "FlxRuntimeShader" => flixel.addons.display.FlxRuntimeShader, #end
 		"ShaderFilter"	=> openfl.filters.ShaderFilter,
 
-		//Extras with abstracts/enums
+		//Abstracts
 		"FlxPoint" => LuaUtils.getMacroAbstractClass("flixel.math.FlxPoint"),
 		"FlxAxes" => LuaUtils.getMacroAbstractClass("flixel.util.FlxAxes"),
 		"FlxColor" => LuaUtils.getMacroAbstractClass("flixel.util.FlxColor")
     ];
+
+	/*
+	 * All of the variables set by using `static var`. These variables can be accessed by all scripts.
+	 * (Note: Be sure to clear this map on mod change to prevent any other mods from using your vars)
+	 */
 	public static var staticVariables:Map<String, Dynamic> = [];
 
     public var parser:Parser;
     public var interp:Interp;
     public var expr:Expr;
+
+	public var variables(get, set):Map<String, Dynamic>;
+	public function get_variables() return interp.variables;
+	public function set_variables(val:Map<String, Dynamic>) {
+		interp.variables = val;
+		return val;
+	}
+
     public var scriptName:String;
-	public var modFolder:String;
+	public var modFolder:Null<String>;
 
-    public function new(path:String, _isHaxeCode:Bool = true) {
-		if(!_isHaxeCode) return; //this field is only really used for runHaxeCode module
+	public var subScripts:Array<psychlua.HScript> = [];
 
-        if (parser == null) initializeModule("parser");
-		if(interp == null) initializeModule("interp");
+    public function new(path:String, ?_parentClass:Dynamic = null, ?_autoRunScript:Bool = true, ?_ignoreErrors:Bool = false) {
+		if(!_autoRunScript) return;
+
+        if(parser == null) initParser();
+		if(interp == null) initInterp();
         scriptName = path;
-		
+
 		#if MODS_ALLOWED
-		if (scriptName != null && scriptName.length > 0) {
+		if(scriptName != null && scriptName.length > 0)
+		{
 			var myFolder:Array<String> = scriptName.trim().split('/');
 			if(myFolder[0] + '/' == Paths.mods() && (Mods.currentModDirectory == myFolder[1] || Mods.getGlobalMods().contains(myFolder[1]))) //is inside mods folder
 				this.modFolder = myFolder[1];
 		}
 		#end
 
-        try {
-            parser.line = 1; //Reset the parser position.
-            expr = parser.parseString(#if sys File.getContent(path) #else Assets.getText(path) #end, path);
-			trace(path);
+		try {
+			parser.line = 1; //Reset the parser position.
+			expr = parser.parseString(#if sys File.getContent(path) #else Assets.getText(path) #end, path);
 
 			interp.variables.set("this", this);
+			for(varToBring => val in classes) interp.variables.set(varToBring, val);
 
-			for (key => value in classes) interp.variables.set(key, value);
-
-            if (FlxG.state is PlayState) {
-                interp.scriptObject = PlayState.instance;
-				interp.publicVariables = PlayState.instance.variables;
-            } else {
-				interp.scriptObject = LuaUtils.getHScriptParent();
-
-				//Prevents the game from printing a null obj reference if the script is added to a state with no variables map
-				if(Reflect.field(interp.scriptObject, "variables") != null) 
-					interp.publicVariables = interp.scriptObject.variables;
-			}
-			addHScriptFuncs(this.interp);
-
-			//importScript is handled in state parent itself unlike T-Bar Engine
-			//interp.variables.set('importScript', importScript);
-
-			interp.variables.set("trace", hscriptTrace);
-			interp.variables.set('getModSetting', function(saveTag:String, ?modName:String = null) {
-				if(modName == null)
-				{
-					if(this.modFolder == null)
-					{
-						FunkinLua.luaTrace('getModSetting: Argument #2 is null and script is not inside a packed Mod folder!', true, false, 0xFFFF0000);
+			this.setParent((_parentClass != null ? _parentClass : LuaUtils.getHScriptParent()));
+			addHScriptExtras(this.interp, LuaUtils.isPlayStateScript(interp.scriptObject));
+			
+			interp.variables.set("getModSetting", function(saveTag:String, ?modName:String = null) {
+				if(modName == null) {
+					if(this.modFolder == null) {
+						HScript.onHaxeTrace('getModSetting: Argument #2 is null and script is not inside a packed Mod folder!', this.interp, "error");
 						return null;
 					}
 					modName = this.modFolder;
@@ -142,20 +163,39 @@ class HScript implements HscriptInterface {
 				return LuaUtils.getModSetting(saveTag, modName);
 			});
 
-            interp.execute(expr);
-            call("onCreate", []);
-        } catch (e) {
-            FlxG.stage.window.alert('Error on Haxe Script.\n${e.toString()}', 'Error on haxe script!');
-        }
-    }
+			interp.variables.set("debugPrint", function(text:Dynamic = "", ?color:FlxColor = null) {
+				#if(LUA_ALLOWED || HSCRIPT_ALLOWED)
+				if(FlxG.state is PlayState)
+					PlayState.instance.addTextToDebug(text, (color ?? FlxColor.WHITE));
+				else #end	
+					HScript.onHaxeTrace(text, this.interp);
+			});
 
-	public static function addHScriptFuncs(obj:Interp) {
+			interp.execute(expr);
+			call("onCreate", []);
+		} catch(e) {
+			if(!_ignoreErrors) FlxG.stage.window.alert('Error on haxe script.\n${e.toString()}', 'Error on Haxe Script!');
+		}
+	}
+
+	public static function addHScriptExtras(obj:Interp, isPlayState:Bool = false) {
 		if(obj == null) return;
 
-		if(FlxG.state is PlayState) {
-			obj.variables.set("game", PlayState.instance);
+		if(isPlayState) {
+			obj.variables.set("game", PlayState.instance); //runHaxeCode moment
+			obj.variables.set("add", function(basic:FlxBasic, ?frontOfChars:Bool = false) {
+				if (frontOfChars) {
+					PlayState.instance.add(basic);
+					return;
+				}
 
-			obj.variables.set('add', PlayState.instance.insert);
+				var position:Int = PlayState.instance.members.indexOf(PlayState.instance.gfGroup);
+				if(PlayState.instance.members.indexOf(PlayState.instance.boyfriendGroup) < position) position = PlayState.instance.members.indexOf(PlayState.instance.boyfriendGroup);
+				else if(PlayState.instance.members.indexOf(PlayState.instance.dadGroup) < position) position = PlayState.instance.members.indexOf(PlayState.instance.dadGroup);
+
+				PlayState.instance.insert(position, basic);
+			});
+
 			obj.variables.set('insert', PlayState.instance.insert);
 			obj.variables.set('remove', PlayState.instance.remove);
 			obj.variables.set('addBehindGF', PlayState.instance.addBehindGF);
@@ -205,14 +245,13 @@ class HScript implements HscriptInterface {
 				});
 			}
 		}
+		obj.variables.set("Function_Stop", LuaUtils.Function_Stop);
+		obj.variables.set("Function_Continue", LuaUtils.Function_Continue);
+		obj.variables.set("Function_StopHScript", LuaUtils.Function_StopHScript);
+		obj.variables.set("Function_StopLua", LuaUtils.Function_StopLua);
+		obj.variables.set("Function_StopAll", LuaUtils.Function_StopAll);
 
 		//other variables
-		obj.variables.set('Function_Stop', LuaUtils.Function_Stop);
-		obj.variables.set('Function_Continue', LuaUtils.Function_Continue);
-		obj.variables.set('Function_StopHScript', LuaUtils.Function_StopHScript);
-		obj.variables.set('Function_StopLua', LuaUtils.Function_StopLua);
-		obj.variables.set('Function_StopAll', LuaUtils.Function_StopAll);
-		
 		obj.variables.set('keyboardJustPressed', function(name:String) return Reflect.getProperty(FlxG.keys.justPressed, name));
 		obj.variables.set('keyboardPressed', function(name:String) return Reflect.getProperty(FlxG.keys.pressed, name));
 		obj.variables.set('keyboardReleased', function(name:String) return Reflect.getProperty(FlxG.keys.justReleased, name));
@@ -286,6 +325,23 @@ class HScript implements HscriptInterface {
 			return false;
 		});
 
+		//TODO: replace this with "$type". This should work for now
+		obj.variables.set("__type__", function(target:Dynamic):String {
+			return switch(Type.typeof(target)) {
+				case TInt: "Int";
+				case TFloat: "Float";
+				case TBool: "Bool";
+				case TObject: "Object";
+				case TFunction: "Function";
+				case TClass(clsInst): //also houses "String"
+					Type.getClassName(clsInst);
+				case TEnum(enmInst):
+					Type.getEnumName(enmInst);
+				case TUnknown: "Unknown";
+				default: "Null";
+			}
+		});
+
 		obj.variables.set("state", FlxG.state);
 		obj.variables.set('buildTarget', LuaUtils.getBuildTarget());
 
@@ -303,7 +359,7 @@ class HScript implements HscriptInterface {
 
 		obj.variables.set("createCallback", function(name:String, func:Dynamic, ?lua:FunkinLua) {
 			if(lua == null) {
-				FunkinLua.luaTrace('createCallback: no script was found or 3rd argument was null!', true, false, 0xFFFF0000);
+				HScript.onHaxeTrace('createCallback: no script was found or 3rd argument was null!', obj, "error");
 				return false;
 			}
 
@@ -312,105 +368,225 @@ class HScript implements HscriptInterface {
 		});
 		#end
 	}
-	
-	//CALLBACKS FOR SCRIPT STUFF
 
-    function hscriptTrace(v:Dynamic) {
-		var posInfos = interp.posInfos();
-		trace(posInfos.fileName + ":" + posInfos.lineNumber + ": " + Std.string(v));
+	//CALLBACKS FOR HSCRIPT
+
+	var _librariesAllowed:Bool = true;
+	function onImportFailed(cl:Array<String>, classAlias:Null<String>):Bool {
+		if(_librariesAllowed) { //Custom hscript libraries
+			var scriptPath = Paths.getScriptPath("libraries/" + cl.join("/") + ".hx", this.modFolder);
+			if(#if sys FileSystem.exists(scriptPath) #else Assets.exists(scriptPath) #end) {
+				return _includeSubscript(scriptPath, true);
+			}
+		}
+
+		return false;
+	}
+
+    public static function onHaxeTrace(v:Dynamic, ?interpreter:Interp, ?level:String = "trace") {
+		var posInfos = (interpreter != null ? interpreter.posInfos() : {fileName: "hscript", lineNumber: 0, className: null, methodName: null});
+
+		#if PRETTY_TRACE
+		switch(level.toLowerCase()) {
+			case "error":
+				Log.error(v, {fileName: posInfos.fileName, lineNumber: posInfos.lineNumber, className: null, methodName: null});
+				return;
+			case "warn":
+				Log.warn(v, {fileName: posInfos.fileName, lineNumber: posInfos.lineNumber, className: null, methodName: null});
+				return;
+		}
+		#end
+
+		trace(Std.string(v), {fileName: posInfos.fileName, lineNumber: posInfos.lineNumber, className: null, methodName: null});
     }
 
     function onError(e:Error) {
-		FunkinLua.luaTrace(Printer.errorToString(e), true, false, 0xFFFF0000);
+		#if PRETTY_TRACE
+		Log.error(Printer.errorToString(e));
+		#else
+		trace(e);
+		#end
     }
 
+	function onWarn(e:Error) {
+		var posInfos = interp.posInfos();
+
+		#if PRETTY_TRACE
+		Log.warn(Printer.errorToString(e), {fileName: posInfos.fileName, lineNumber: posInfos.lineNumber, className: null, methodName: null});
+		#else
+		trace(Printer.errorToString(e), {fileName: posInfos.fileName, lineNumber: posInfos.lineNumber, className: null, methodName: null});
+		#end
+	}
+
 	//BACKEND FUNCTIONS
+
 	public function setPublicMap(map:Map<String, Dynamic>) {
 		if(interp != null) interp.publicVariables = map;
 		return this;
 	}
 
 	public function setParent(parent:Dynamic) {
-		if(interp != null) interp.scriptObject = parent;
+		if(interp != null) {
+			interp.scriptObject = parent;
+			if(parent.variables != null) interp.publicVariables = parent.variables;
+		}
 		return this;
 	}
 
-    public function initializeModule(toInit:String) {
-		switch(toInit) {
-			case "parser":
-				parser = new hscript.Parser();
-				parser.allowJSON = parser.allowMetadata = parser.allowTypes = true;
-				parser.preprocessorValues = LuaUtils.hscriptPreprocessors;
+	public function getScriptParent():Dynamic
+		return interp.scriptObject;
 
-			case "interp":
-				interp = new Interp();
-				interp.allowStaticVariables = interp.allowPublicVariables = true;
-				interp.staticVariables = staticVariables;
-				interp.errorHandler = onError;
+	function _includeSubscript(path:String, absolute:Bool = false):Bool {
+		var scriptPath = (absolute ? path : Paths.getScriptPath(path, this.modFolder));
+
+		if(#if sys FileSystem.exists(scriptPath) #else Assets.exists(scriptPath) #end) {
+			var hscriptToPush = new HScript(scriptPath, this.getScriptParent(), true, true);
+			hscriptToPush.call("onScriptImported", [this]);
+			subScripts.push(hscriptToPush);
+			return true;
 		}
-    }
+
+		HScript.onHaxeTrace('Path "$scriptPath" does not exist!', this.interp, "error");
+		return false;
+	}
+
+	public function initParser() {
+		parser = new hscript.Parser();
+		parser.allowJSON = parser.allowMetadata = parser.allowTypes = parser.allowRegex = true;
+		parser.preprocessorValues = LuaUtils.preprocessors;
+	}
+ 
+	public function initInterp() {
+		interp = new Interp();
+		interp.allowStaticVariables = interp.allowPublicVariables = true;
+		interp.staticVariables = staticVariables;
+
+		interp.onMetadata = onMetadata;
+		interp.errorHandler = onError;
+		interp.warnHandler = onWarn;
+		interp.importFailedCallback = onImportFailed;
+	}
+
+	/*
+	 * All of the custom metadatas (@:exampleMeta) that can be used in hscript.
+	 */
+	public function onMetadata(name:String, args:Array<Expr>, exp:Expr) {
+		switch(name) {
+			case ":ignoreException": this.parser.resumeErrors = true;
+			case ":noDebug": this.interp.errorHandler = (e) -> {};
+			case ":noLibraries": this._librariesAllowed = false;
+
+			case ":include":
+				var _isAbsolute:Bool = false;
+				if(args.length > 1) _isAbsolute = switch(args[1].e) { case EIdent(abs): (abs.trim() == "true"); default: false; }
+
+				switch(args[0].e) {
+					case EConst(CString(scriptPath)): _includeSubscript(Std.string(scriptPath.trim()), _isAbsolute);
+					default: //nothing
+				}
+				return null;
+		}
+		return null;
+	}
 
 	//SCRIPT CALLBACKS
 	public function stop() {
-        expr = null;
-        interp = null;
-		parser = null;
-    }
+		for(sub in subScripts) {
+			sub.call("onDestroy", []);
+			sub.stop();
+		}
+		subScripts = [];
 
-	public function get(name:String)
-		return interp.variables.get(name) ?? null;
+		expr = null;
+		interp = null;
+	}
 
+	public function get(name:String):Dynamic
+		return (interp != null ? interp.variables.get(name) : null);
 
 	public function set(variable:String, data:Dynamic)
 		if(interp != null) interp.variables.set(variable, data);
 
-    public function call(func:String, ?args:Array<Dynamic>):Dynamic {
-		if (interp == null) return null;
+	public function call(func:String, ?args:Array<Dynamic>):Dynamic {
+		if(interp == null) return null;
 
-		var funcToRun = {func: interp.variables.get(func), hasArgs: (args != null && args.length > 0)};
-        if (funcToRun.func == null || !Reflect.isFunction(funcToRun.func)) return null;
-        return funcToRun.hasArgs ? Reflect.callMethod(null, funcToRun.func, args) : funcToRun.func();
-    }
+		var functionVar = interp.variables.get(func);
+		if(functionVar == null || !Reflect.isFunction(functionVar)) return null;
+		return (args != null && args.length > 0) ? Reflect.callMethod(null, functionVar, args) : functionVar();
+	}
 }
 
+#else
+
+/* Ignore this. It's for if hscript is removed */
+class HScript {
+	public function new(path:String, ?_parentClass:Dynamic, ?_autoRunScript:Bool, ?_ignoreErrors:Bool) {
+		throw "HScript is not supported on this platform!";
+	}
+}
+
+#end
+
 class HaxeCode extends HScript {
+	#if LUA_ALLOWED
 	public var parentLua:FunkinLua;
+	#else
+	public var parentLua:Dynamic;
+	#end
 
-	public var variables(get, never):Map<String, Dynamic>;
-	public function get_variables() return interp.variables;
+	#if LUA_ALLOWED
+	override public function new(?parent:FunkinLua)
+	#else
+	override public function new(?parent:Dynamic)
+	#end
+	{
+		super(null, null, false, false); //legally forced to put this by the haxe gods
 
-	override public function new(?parent:FunkinLua) {
-		super(null, false);
+		#if HSCRIPT_ALLOWED
+		if(parser == null) this.initParser();
+		if(interp == null) this.initInterp();
 
-		if(parser == null) this.initializeModule("parser");
-		if(interp == null) this.initializeModule("interp");
-
-		interp.scriptObject = LuaUtils.getHScriptParent();
+		if(FlxG.state is PlayState) this.setParent(PlayState.instance);
+		else this.setParent(LuaUtils.getHScriptParent());
 
 		for(key => value in HScript.classes) interp.variables.set(key, value);
 
+		interp.variables.set('this', this);
 		interp.variables.set('Alphabet', objects.Alphabet);
 		interp.variables.set('CustomSubstate', psychlua.CustomSubstate);
 
-		interp.variables.set('this', this);
-		HScript.addHScriptFuncs(interp);
+		HScript.addHScriptExtras(interp, LuaUtils.isPlayStateScript(interp.scriptObject));
 
-		this.parentLua = parent;
-		interp.variables.set('parentLua', #if LUA_ALLOWED parent #else null #end);
-		interp.variables.set('scriptName', #if LUA_ALLOWED parent.scriptName #else null #end);
+		if(parent != null) {
+			this.parentLua = parent;
+			interp.variables.set('parentLua', #if LUA_ALLOWED parent #else null #end);
+			interp.variables.set('scriptName', #if LUA_ALLOWED parent.scriptName #else null #end);
+		}
+		#end
+	}
+
+	#if HSCRIPT_ALLOWED
+	override function initInterp() {
+		interp = new Interp();
+		interp.onMetadata = this.onMetadata;
+		interp.importFailedCallback = this.onImportFailed;
 	}
 
 	public function execute(codeToRun:String):Dynamic {
-		if(parser == null) this.initializeModule("parser");
-		if(interp == null) this.initializeModule("interp");
+		if(parser == null) initParser();
 		parser.line = 1;
 
 		return interp.execute(parser.parseString(codeToRun, (parentLua != null ? '${parentLua.scriptName}:runHaxeCode' : 'hscript')));
 	}
 
-	public function executeFunction(func:String, ?args:Array<Dynamic> = null):Dynamic
-		return this.call(func, args);
+	public function destroy() {
+		expr = null;
+		interp = null;
+		parser = null;
+	}
+	#end
 
+	#if LUA_ALLOWED
 	public static function implement(funk:FunkinLua) {
 		if(funk == null) return;
 
@@ -419,9 +595,8 @@ class HaxeCode extends HScript {
 			#if HSCRIPT_ALLOWED
 			try {
 				returnVal = funk.hscript.execute(codeToRun);
-				if(returnVal != null)
-					return (returnVal == null || LuaUtils.isOfTypes(returnVal, [Bool, Int, Float, String, Array])) ? returnVal : null;
-			} catch (e:Dynamic) {
+				return (LuaUtils.isLuaSupported(returnVal) ? returnVal : null);
+			} catch(e:Dynamic) {
 				FunkinLua.luaTrace('${funk.scriptName}:${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
 			}
 			#else
@@ -430,28 +605,6 @@ class HaxeCode extends HScript {
 			return returnVal;
 		});
 
-		funk.addLocalCallback("addHaxeLibrary", function(libName:String, ?libPackage:String = '') {
-			#if HSCRIPT_ALLOWED
-			var str:String = '';
-			if(libPackage.length > 0) str = libPackage + '.';
-			else if(libName == null) libName = '';
-
-			var classObj:Dynamic = Type.resolveClass(str + libName);
-			if(classObj == null) classObj = LuaUtils.getMacroAbstractClass(str + libName);
-			if(classObj == null) classObj = Type.resolveEnum(str + libName);
-			if(funk.hscript == null) return;
-
-			try {
-				if (classObj != null) funk.hscript.variables.set(libName, classObj);
-			} catch(e:Dynamic) {
-				FunkinLua.luaTrace('${funk.scriptName}:${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
-			}
-
-			#else
-			FunkinLua.luaTrace("addHaxeLibrary: HScript isn't supported on this platform!", false, false, FlxColor.RED);
-			#end
-		});
-		
 		funk.addLocalCallback("runHaxeFunction", function(funcToRun:String, ?funcArgs:Array<Dynamic> = null) {
 			#if HSCRIPT_ALLOWED
 			if(!funk.hscript.variables.exists(funcToRun)) {
@@ -460,8 +613,7 @@ class HaxeCode extends HScript {
 			}
 
 			try {
-				var callValue = funk.hscript.executeFunction(funcToRun, funcArgs);
-				return callValue;
+				return funk.hscript.call(funcToRun, funcArgs);
 			} catch(e:Dynamic) {
 				FunkinLua.luaTrace('${funk.scriptName}:${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
 			}
@@ -471,11 +623,34 @@ class HaxeCode extends HScript {
 
 			return null;
 		});
-	}
 
-	public function destroy() {
-		expr = null;
-        interp = null;
-		parser = null;
+		funk.addLocalCallback("addHaxeLibrary", function(libName:String, ?libPackage:String = '') {
+			#if HSCRIPT_ALLOWED
+			if(funk.hscript == null) return;
+
+			var str:String = '';
+			if(libPackage.length > 0) str = libPackage + '.';
+			else if(libName == null) libName = '';
+
+			var classObj:Dynamic = Type.resolveClass(str + libName);
+			if(classObj == null) classObj = LuaUtils.getMacroAbstractClass(str + libName); //If the class doesn't exist, then it checks for an hscript generated abstract class
+			if(classObj == null) classObj = Type.resolveEnum(str + libName); //If the class STILL doesn't exist, then it checks for an enum
+
+			try {
+				if(classObj != null)
+					funk.hscript.variables.set(libName, classObj);
+				else
+					FunkinLua.luaTrace("addHaxeLibrary: Library \"" + (str + libName) + "\" does not exist!", false, false, FlxColor.RED);
+
+			} catch(e:Dynamic) {
+				FunkinLua.luaTrace('${funk.scriptName}:${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
+			}
+			FunkinLua.luaTrace("addHaxeLibrary is deprecated! Import classes using the \"import\" keyword instead!", false, true);
+
+			#else
+			FunkinLua.luaTrace("addHaxeLibrary: HScript isn't supported on this platform!", false, false, FlxColor.RED);
+			#end
+		});
 	}
+	#end
 }

--- a/source/psychlua/LuaUtils.hx
+++ b/source/psychlua/LuaUtils.hx
@@ -512,21 +512,31 @@ class LuaUtils
 		}
 		return PlayState.instance.camGame;
 	}
-	
-	#if HSCRIPT_ALLOWED
-	public static var hscriptPreprocessors(get, never):Map<String, Dynamic>;
-	public static function get_hscriptPreprocessors() {
-		var preprocessors:Map<String, Dynamic> = backend.Macro.compilerDefines;
-		preprocessors.set("GHOST_ENGINE", true);
-		preprocessors.set("GHOST_ENGINE_VER", Global.forkVersion);
-		preprocessors.set("GHOST_ENGINE_STAGE", Global.forkStage);
-		preprocessors.set("BUILD_TARGET", LuaUtils.getBuildTarget());
 
-		return preprocessors;
+	// https://github.com/ShadowMario/FNF-PsychEngine/commit/cf674627b40fa8f06a0a7b74ddc6b403ebfcf138
+	public static function isLuaSupported(value:Any):Bool {
+		return (value == null || isOfTypes(value, [Bool, Int, Float, String, Array]) || Type.typeof(value) == ValueType.TObject);
 	}
-	
+
+	#if HSCRIPT_ALLOWED
+	public static var preprocessors(get, never):Map<String, Dynamic>;
+	public static function get_preprocessors() {
+		var _preprocessors:Map<String, Dynamic> = backend.Macro.compilerDefines;
+
+		_preprocessors.set("GHOST_ENGINE", true);
+		_preprocessors.set("GHOST_ENGINE_VER", Global.forkVersion);
+		_preprocessors.set("GHOST_ENGINE_STAGE", Global.forkStage);
+		_preprocessors.set("BUILD_TARGET", LuaUtils.getBuildTarget());
+
+		return _preprocessors;
+	}
+
 	public static function getHScriptParent():Dynamic {
 		return (FlxG.state.subState == null ? FlxG.state : FlxG.state.subState);
+	}
+
+	public static function isPlayStateScript(obj:Dynamic):Bool {
+		return (obj is PlayState && !(obj is flixel.FlxSubState));
 	}
 
 	@:noUsing public static inline function getMacroAbstractClass(className:String) return Type.resolveClass('${className}_HSC');


### PR DESCRIPTION
- (RECOMMENDED) Install latest hxcpp library with `haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git`.
- Install latest hscript library with `haxelib set hscript-improved-dev https://github.com/CodenameCrew/hscript-improved.git codename-dev`
- `setup.bat` now includes the required classes & versions for the fork.
- HScript Library improved to include:
	1: Final Classes in Custom Classes.
	2: Statics in Custom Classes (ex: `static var`).
	3: Type checking for Custom Classes (`is` operator).
	4: Extending other Custom Classes.
	5: Enums & Enum pattern matching with `switch case`.
	6: Property Accessors for variables (ex: `myvar(get, set):Int;`) & compatibility with `@:bypassAccessor`.
	7: `@:isVar` compatibility with Property Accessors.
	8: Static Extension support (`using`) for both Custom Classes & real Classes.
	9: Allow using Type parameters for creating objects (ex: `var a = new TypedObject<Int>();`).
	10: `package` declaration support.
	
	11: Static Imports (ex: `import haxe.io.Path.normalize;`), with support for aliases (`as`).
	12: Importing a class & using an alias that starts with a lowercase letter errors.
	13: `cast` support, both safe and unsafe cast. This is ignored by the interpreter and will return the normal value.
	14: String Interpolation support (ex: `trace('The sum of 15 / 3 is ${15 / 3}');`).
	15: Regex keyword `~/` support without having to import EReg (ex: `var regexSupport = ~/123456789/;`).

-HScript class improved to include:
	1: Custom script library importing using `import` keyword or with `@:include` metadata.
	2: New metadatas from T-Bar Engine, like `@:ignoreException`, `@:noDebug`, `@:noLibraries`, and `@:include`.
	3: If importing script using `import` or with `@:include`, the script will call `onScriptImported`.
	4: Updated Preprocessor checking (ex: `#if(GHOST_ENGINE_VER >= 0.0.1) trace("hi!"); #end`).
	5: Most common base level classes pre-imported (`Type`, `Sys`, `Date`, `Math`, etc.).

- Macro.hx includes all openfl classes and most lime classes into the build (Increases compile times, can be disabled by removing the `Compiler.include` function in the `compileMacros` function).